### PR TITLE
🧊 Chore: Shelve File API (v0.4.0) — HTTP 404 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Command-line interface for the [MiniMax Token Plan](https://platform.minimax.io/
 
 Generate text, images, video, speech, and music from the terminal. Supports both the **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) platforms with automatic region detection.
 
-## What's New (v0.4.0)
+## What's New (v0.3.0)
 
-**File management + Vision `file_id` support:**
+**`minimax config export-schema`** — export all commands as Anthropic/OpenAI-compatible JSON tool schemas with a single command:
 
 ```bash
-FILE_ID=$(minimax file upload --file image.png --quiet)
-minimax vision describe --file-id $FILE_ID --prompt "这张图里有几个人？"
+minimax config export-schema | jq .
+minimax config export-schema --command "video generate" | jq .
 ```
 
-Also new in v0.3.0: **`minimax config export-schema`** — export all commands as Anthropic/OpenAI-compatible JSON tool schemas with a single command. See [Changelog](#changelog) for full version history.
+See [Changelog](#changelog) for full version history.
 
 ## Installation
 
@@ -86,9 +86,6 @@ minimax image generate --non-interactive
 | `video generate` | Generate a video (auto-downloads on completion) |
 | `video task get` | Query video task status |
 | `video download` | Download a completed video |
-| `file upload` | Upload a file to MiniMax storage |
-| `file list` | List uploaded files |
-| `file delete` | Delete an uploaded file |
 | `music generate` | Generate a song |
 | `search query` | Web search |
 | `vision describe` | Describe an image (supports `--file-id` to skip base64) |
@@ -126,10 +123,6 @@ minimax music generate --prompt "Indie folk" --lyrics "La la la..." --out song.m
 
 # Web search
 minimax search query --q "MiniMax AI latest news"
-
-# File management (for reuse in vision/video)
-FILE_ID=$(minimax file upload --file image.png --purpose vision --quiet)
-minimax vision describe --file-id $FILE_ID
 
 # Export Agent tool schemas
 minimax config export-schema | jq .
@@ -203,20 +196,13 @@ bun run build              # Build standalone binaries
 
 ## Changelog
 
-### v0.4.0 — File Management API + Vision file_id Support
+### v0.4.0 — File Management API (🧊 Shelved)
 
-**New `file` resource group:**
-- `minimax file upload` — upload local file, get `file_id`; `--quiet` outputs only the ID
-- `minimax file list` — formatted table of uploaded files
-- `minimax file delete` — remove file by ID
-
-**Vision `--file-id` support:**
-- `vision describe` now accepts `--file-id` as mutually exclusive alternative to `--image`
-- With `--file-id`: sends `{prompt, file_id}` directly to VLM API (no base64)
-- With `--image`: existing base64 encoding path unchanged
-- Interactive TTY prompt detects whether input is path/URL or fileId
-
-Note: MiniMax File API returned HTTP 404 with the current API key. Endpoint paths and request handling are verified correct via `--verbose` mode.
+> **🧊 Shelved:** File API returned HTTP 404 with current API key. This feature is temporarily hidden until the endpoint permissions are officially opened.
+> - `minimax file upload` — upload local file, get `file_id`
+> - `minimax file list` — formatted table of uploaded files
+> - `minimax file delete` — remove file by ID
+> - `vision describe --file-id` — use pre-uploaded file instead of base64
 
 ### v0.3.0 — Agent Tool Schema Auto-Generation
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -20,9 +20,10 @@ import quotaShow from './commands/quota/show';
 import configShow from './commands/config/show';
 import configSet from './commands/config/set';
 import configExportSchema from './commands/config/export-schema';
-import fileUpload from './commands/file/upload';
-import fileList from './commands/file/list';
-import fileDelete from './commands/file/delete';
+// ❄️ 暂时雪藏 File API (等待接口权限开放)
+// import fileUpload from './commands/file/upload';
+// import fileList from './commands/file/list';
+// import fileDelete from './commands/file/delete';
 import update from './commands/update';
 
 import type { Config } from './config/schema';
@@ -192,7 +193,6 @@ Resources:
   music      Music generation (generate)
   search     Web search (query)
   vision     Image understanding (describe)
-  file       File management (upload, list, delete)
   quota      Usage quotas (show)
   config     CLI configuration (show, set, export-schema)
   update     Update minimax to a newer version
@@ -272,8 +272,11 @@ export const registry = new CommandRegistry({
   'config show':      configShow,
   'config set':       configSet,
   'config export-schema': configExportSchema,
-  'file upload':      fileUpload,
-  'file list':        fileList,
-  'file delete':      fileDelete,
+
+  // ❄️ 暂时雪藏 File API
+  // 'file upload':      fileUpload,
+  // 'file list':        fileList,
+  // 'file delete':      fileDelete,
+
   'update':           update,
 });


### PR DESCRIPTION
## 原因

当前 API key 缺少文件上传权限，minimax file upload 接口返回 HTTP 404 错误。经 --verbose 模式验证，接口路径和请求处理逻辑均正确，问题源于 MiniMax 官方尚未开放 File API 权限。

## 改动内容

### 1. src/registry.ts
- 注释掉 file upload/list/delete 三个命令的 import 和注册
- 从 help 文本中移除 file 资源组
- 代码完整保留，恢复时只需取消注释

### 2. README.md
- What's New：降级为 v0.3.0，移除 File API 相关描述
- Commands 表格：删除 file upload/list/delete 三行
- Examples：删除 File management 示例段落
- Changelog：v0.4.0 标记为 🧊 Shelved，注明原因

## 恢复方式

接口权限开放后，取消 src/registry.ts 中的注释即可快速恢复：



## 验证

```bash
minimax --help | grep file   # 应无输出
minimax file upload          # 应提示 Unknown command
```