### PR TITLE
docs: add agent skill guide, simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,229 +1,67 @@
 # minimax-cli
 
-Command-line interface for the [MiniMax Token Plan](https://platform.minimax.io/docs/token-plan/intro).
+CLI for the [MiniMax AI Platform](https://platform.minimax.io) — generate text, images, video, speech, and music from the terminal.
 
-```
-  __  __ ___ _   _ ___ __  __    _   __  __
- |  \/  |_ _| \ | |_ _|  \/  |  / \ \ \/ /
- | |\/| || ||  \| || || |\/| | / _ \ \  /
- | |  | || || |\  || || |  | |/ ___ \/  \
- |_|  |_|___|_| \_|___|_|  |_/_/   \_\_/\
-```
+Supports **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) with automatic region detection.
 
-Generate text, images, video, speech, and music from the terminal. Supports both the **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) platforms with automatic region detection.
-
-## What's New (v0.3.0)
-
-**`minimax config export-schema`** — export all commands as Anthropic/OpenAI-compatible JSON tool schemas with a single command:
-
-```bash
-minimax config export-schema | jq .
-minimax config export-schema --command "video generate" | jq .
-```
-
-See [Changelog](#changelog) for full version history.
-
-## Installation
-
-### Standalone binary (recommended)
+## Install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/minimax-cli/main/install.sh | sh
 ```
 
-### npm
+Or via npm / bun:
 
 ```bash
 npm install -g minimax-cli
 ```
 
-### bun
-
-```bash
-bun install -g minimax-cli
-```
-
-### From source
-
-```bash
-git clone https://github.com/MiniMax-AI-Dev/minimax-cli.git && cd minimax-cli
-bun install
-bun run dev -- --help
-```
-
-## Quick start
+## Quick Start
 
 ```bash
 minimax auth login --api-key sk-xxxxx
-minimax text chat --message "user:What is MiniMax?"
-minimax image generate --prompt "A cat in a spacesuit on Mars"
+minimax text chat --message "What is MiniMax?"
+minimax image generate --prompt "A cat in a spacesuit"
+minimax video generate --prompt "Ocean waves at sunset"
 minimax speech synthesize --text "Hello!" --out hello.mp3
+minimax music generate --prompt "Indie folk" --lyrics "La la la..."
 minimax vision describe --image photo.jpg
-```
-
-## Agent & CI usage
-
-```bash
-# Async: get task ID immediately, no blocking
-minimax video generate --prompt "A robot." --async --quiet
-# → {"taskId":"..."}
-
-# Pipe-friendly: stdout is pure data, stderr is progress
-minimax text chat --message "Hi" | jq .
-
-# CI: missing args fail fast with clear errors
-minimax image generate --non-interactive
-# → Error: Missing required argument: --prompt
+minimax search query --q "MiniMax AI latest news"
 ```
 
 ## Commands
 
 | Command | Description |
 |---|---|
-| `text chat` | Send a chat completion |
-| `speech synthesize` | Text-to-speech, up to 10k chars |
-| `image generate` | Generate images |
-| `video generate` | Generate a video (auto-downloads on completion) |
-| `video task get` | Query video task status |
-| `video download` | Download a completed video |
-| `music generate` | Generate a song |
+| `text chat` | Chat completion (MiniMax-M2.7) |
+| `image generate` | Image generation (image-01) |
+| `video generate` | Video generation (Hailuo-2.3) |
+| `speech synthesize` | Text-to-speech (speech-2.8-hd) |
+| `music generate` | Music generation (music-2.5) |
+| `vision describe` | Image understanding (VLM) |
 | `search query` | Web search |
-| `vision describe` | Describe an image (supports `--file-id` to skip base64) |
-| `quota show` | Show usage quotas |
+| `quota show` | Usage quotas |
+| `config show / set` | Configuration |
 | `config export-schema` | Export tool schemas as JSON |
-| `config show` / `config set` | View or update configuration |
 | `auth login/status/refresh/logout` | Authentication |
+| `update` | Self-update |
 
-All commands accept [global flags](#global-flags).
+Run `minimax <command> --help` for full options.
 
-## Examples
+## Agent / CI Usage
 
-```bash
-# Text chat
-minimax text chat --message "user:Write fizzbuzz"
-minimax text chat --message "Hi" --stream
-
-# Image generation
-minimax image generate --prompt "Sunset over ocean" --aspect-ratio 16:9 --n 3
-
-# Vision (path/URL or pre-uploaded file ID)
-minimax vision describe --image photo.jpg --prompt "What breed is this?"
-minimax vision describe --file-id file-123 --prompt "Extract the text"
-
-# Video (auto-downloads to ~/.minimax-video/ on completion)
-minimax video generate --prompt "A man reads a book."
-minimax video generate --prompt "A robot." --async --quiet
-
-# Speech synthesis
-minimax speech synthesize --text "Hello world!" --out hello.mp3
-minimax speech synthesize --text "Breaking news." --text-file - --stream | mpv -
-
-# Music generation
-minimax music generate --prompt "Indie folk" --lyrics "La la la..." --out song.mp3
-
-# Web search
-minimax search query --q "MiniMax AI latest news"
-
-# Export Agent tool schemas
-minimax config export-schema | jq .
-minimax config export-schema --command "video generate" | jq .
-
-# Auth
-minimax auth login --api-key sk-xxxxx
-minimax auth status
-```
-
-## Global flags
-
-| Flag | Description |
-|---|---|
-| `--api-key <key>` | API key (overrides all other auth) |
-| `--region <region>` | `global` (default) or `cn` |
-| `--base-url <url>` | Override API base URL |
-| `--output <format>` | `text`, `json`, or `yaml` |
-| `--quiet` | Suppress non-essential output to stderr |
-| `--verbose` | Print HTTP request/response details |
-| `--timeout <seconds>` | Request timeout (default: 300) |
-| `--no-color` | Disable ANSI colors and spinners |
-| `--yes` | Skip confirmation prompts |
-| `--dry-run` | Show what would happen without executing |
-| `--non-interactive` | Disable interactive prompts (CI/agent use) |
-| `--async` | Return task ID immediately without polling |
-| `--version` / `--help` | Version and help |
-
-## Output philosophy
-
-- `stdout` → result data only (text, file paths, JSON)
-- `stderr` → spinners, region detection, help text, warnings, verbose logs
+See [skill/SKILL.md](skill/SKILL.md) for the complete agent integration guide, including all command signatures, tool schema export, and piping patterns.
 
 ```bash
-# stdout is clean JSON — pipe to jq safely
-minimax text chat --message "Hi" | jq .
-
-# stderr shows spinner without polluting the pipe
-minimax video generate --prompt "Ocean waves." 2>/dev/null
+minimax video generate --prompt "A robot." --async --quiet   # non-blocking
+minimax text chat --message "Hi" --output json | jq .        # pipe-friendly
+minimax config export-schema | jq .                          # tool schemas
 ```
 
-## Configuration
+## Output Philosophy
 
-Precedence (highest to lowest): CLI flags → env vars → `~/.minimax/config.yaml` → defaults.
-
-```bash
-minimax config set --key region --value cn
-export MINIMAX_REGION=cn
-```
-
-## Exit codes
-
-| Code | Meaning |
-|---|---|
-| 0 | Success |
-| 1 | General error |
-| 2 | Usage error (bad flags, missing arguments) |
-| 3 | Authentication error |
-| 4 | Quota exceeded |
-| 5 | Timeout |
-| 10 | Content filter triggered |
-
-## Building
-
-```bash
-bun run dev -- <command>   # Run from source
-bun run typecheck          # Type check
-bun test                   # Run tests
-bun run build              # Build standalone binaries
-```
-
-## Changelog
-
-### v0.4.0 — File Management API (🧊 Shelved)
-
-> **🧊 Shelved:** File API returned HTTP 404 with current API key. This feature is temporarily hidden until the endpoint permissions are officially opened.
-> - `minimax file upload` — upload local file, get `file_id`
-> - `minimax file list` — formatted table of uploaded files
-> - `minimax file delete` — remove file by ID
-> - `vision describe --file-id` — use pre-uploaded file instead of base64
-
-### v0.3.0 — Agent Tool Schema Auto-Generation
-
-- `OptionDef` interface extended with optional `type` and `required` fields
-- New `CommandRegistry.getAllCommands()` traversal method
-- `src/utils/schema.ts`: parses `--flag <value>` strings into Anthropic/OpenAI-compatible tool schemas
-- New command: `minimax config export-schema` — exports all tool schemas as clean JSON to stdout
-- Core commands marked `required: true`: `image generate --prompt`, `text chat --message`, `video generate --prompt`, `vision describe --image`
-
-### v0.2.0 — Agent & CI Compatibility
-
-- `src/utils/env.ts`: `isInteractive()` and `isCI()` helpers
-- `--non-interactive`: forces non-interactive mode regardless of TTY state
-- `--async`: immediate task-ID return without blocking poll
-- All help routes to stderr (not stdout) — `--help | jq` works cleanly
-- Streaming: thinking blocks go to stderr in non-TTY mode; final text always to stdout
-- Interactive fallback: missing args prompt in TTY, fail fast in CI/agent mode
-
-### v0.1.0 — Initial release
-
-Text chat with streaming · Image generation with batch and subject reference · Video generation with polling and download · Music generation with lyrics · Speech synthesis with voice customization · Web search · Image understanding · OAuth and API key authentication · Automatic region detection (global vs CN) · YAML/JSON/text output formats
+- `stdout` → data only (text, paths, JSON)
+- `stderr` → spinners, warnings, help
 
 ## License
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,325 @@
+# MiniMax CLI — Agent Skill Guide
+
+Use `minimax` to generate text, images, video, speech, music, and perform web search via the MiniMax AI platform.
+
+## Prerequisites
+
+```bash
+# Auth (persisted to ~/.minimax/credentials.yaml)
+minimax auth login --api-key sk-xxxxx
+
+# Or pass per-call
+minimax text chat --api-key sk-xxxxx --message "Hello"
+```
+
+Region is auto-detected. Override with `--region global` or `--region cn`.
+
+---
+
+## Agent Flags
+
+Always use these flags in non-interactive (agent/CI) contexts:
+
+| Flag | Purpose |
+|---|---|
+| `--non-interactive` | Fail fast on missing args instead of prompting |
+| `--quiet` | Suppress spinners/progress; stdout is pure data |
+| `--output json` | Machine-readable JSON output |
+| `--async` | Return task ID immediately (video generation) |
+| `--dry-run` | Preview the API request without executing |
+| `--yes` | Skip confirmation prompts |
+
+---
+
+## Commands
+
+### text chat
+
+Chat completion. Default model: `MiniMax-M2.7`.
+
+```bash
+minimax text chat --message <text> [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
+| `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
+| `--system <text>` | string | System prompt |
+| `--model <model>` | string | Model ID (default: `MiniMax-M2.7`) |
+| `--max-tokens <n>` | number | Max tokens (default: 4096) |
+| `--temperature <n>` | number | Sampling temperature (0.0, 1.0] |
+| `--top-p <n>` | number | Nucleus sampling threshold |
+| `--stream` | boolean | Stream tokens (default: on in TTY) |
+| `--tool <json-or-path>` | string, repeatable | Tool definition JSON or file path |
+
+```bash
+# Single message
+minimax text chat --message "user:What is MiniMax?" --output json --quiet
+
+# Multi-turn
+minimax text chat \
+  --system "You are a coding assistant." \
+  --message "user:Write fizzbuzz in Python" \
+  --output json
+
+# From file
+cat conversation.json | minimax text chat --messages-file - --output json
+```
+
+**stdout**: response text (text mode) or full response object (json mode).
+
+---
+
+### image generate
+
+Generate images. Model: `image-01`.
+
+```bash
+minimax image generate --prompt <text> [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--prompt <text>` | string, **required** | Image description |
+| `--aspect-ratio <ratio>` | string | e.g. `16:9`, `1:1` |
+| `--n <count>` | number | Number of images (default: 1) |
+| `--subject-ref <params>` | string | Subject reference: `type=character,image=path-or-url` |
+| `--out-dir <dir>` | string | Download images to directory |
+| `--out-prefix <prefix>` | string | Filename prefix (default: `image`) |
+
+```bash
+minimax image generate --prompt "A cat in a spacesuit" --output json --quiet
+# stdout: image URLs (one per line in quiet mode)
+
+minimax image generate --prompt "Logo" --n 3 --out-dir ./gen/ --quiet
+# stdout: saved file paths (one per line)
+```
+
+---
+
+### video generate
+
+Generate video. Default model: `MiniMax-Hailuo-2.3`. This is an async task — by default it polls until completion.
+
+```bash
+minimax video generate --prompt <text> [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--prompt <text>` | string, **required** | Video description |
+| `--model <model>` | string | `MiniMax-Hailuo-2.3` (default) or `MiniMax-Hailuo-2.3-Fast` |
+| `--first-frame <path-or-url>` | string | First frame image |
+| `--callback-url <url>` | string | Webhook URL for completion |
+| `--download <path>` | string | Save video to specific file |
+| `--async` | boolean | Return task ID immediately |
+| `--no-wait` | boolean | Same as `--async` |
+| `--poll-interval <seconds>` | number | Polling interval (default: 5) |
+
+```bash
+# Non-blocking: get task ID
+minimax video generate --prompt "A robot." --async --quiet
+# stdout: {"taskId":"..."}
+
+# Blocking: wait and get file path
+minimax video generate --prompt "Ocean waves." --download ocean.mp4 --quiet
+# stdout: ocean.mp4
+```
+
+### video task get
+
+Query status of a video generation task.
+
+```bash
+minimax video task get --task-id <id> [--output json]
+```
+
+### video download
+
+Download a completed video by task ID.
+
+```bash
+minimax video download --task-id <id> [--out <path>]
+```
+
+---
+
+### speech synthesize
+
+Text-to-speech. Default model: `speech-2.8-hd`. Max 10k chars.
+
+```bash
+minimax speech synthesize --text <text> [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--text <text>` | string | Text to synthesize |
+| `--text-file <path>` | string | Read text from file. Use `-` for stdin |
+| `--model <model>` | string | `speech-2.8-hd` (default), `speech-2.6`, `speech-02` |
+| `--voice <id>` | string | Voice ID (default: `English_expressive_narrator`) |
+| `--speed <n>` | number | Speed multiplier |
+| `--volume <n>` | number | Volume level |
+| `--pitch <n>` | number | Pitch adjustment |
+| `--format <fmt>` | string | Audio format (default: `mp3`) |
+| `--sample-rate <hz>` | number | Sample rate (default: 32000) |
+| `--bitrate <bps>` | number | Bitrate (default: 128000) |
+| `--channels <n>` | number | Audio channels (default: 1) |
+| `--language <code>` | string | Language boost |
+| `--subtitles` | boolean | Include subtitle timing data |
+| `--pronunciation <from/to>` | string, repeatable | Custom pronunciation |
+| `--sound-effect <effect>` | string | Add sound effect |
+| `--out <path>` | string | Save audio to file |
+| `--stream` | boolean | Stream raw audio to stdout |
+
+```bash
+minimax speech synthesize --text "Hello world" --out hello.mp3 --quiet
+# stdout: hello.mp3
+
+echo "Breaking news." | minimax speech synthesize --text-file - --out news.mp3
+```
+
+---
+
+### music generate
+
+Generate music. Model: `music-2.5`.
+
+```bash
+minimax music generate --prompt <text> [--lyrics <text>] [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--prompt <text>` | string | Music style description |
+| `--lyrics <text>` | string | Song lyrics |
+| `--lyrics-file <path>` | string | Read lyrics from file. Use `-` for stdin |
+| `--format <fmt>` | string | Audio format (default: `mp3`) |
+| `--sample-rate <hz>` | number | Sample rate (default: 44100) |
+| `--bitrate <bps>` | number | Bitrate (default: 256000) |
+| `--out <path>` | string | Save audio to file |
+| `--stream` | boolean | Stream raw audio to stdout |
+
+At least one of `--prompt` or `--lyrics` is required.
+
+```bash
+minimax music generate --prompt "Upbeat pop" --lyrics "La la la..." --out song.mp3 --quiet
+```
+
+---
+
+### vision describe
+
+Image understanding via VLM. Provide either `--image` or `--file-id`, not both.
+
+```bash
+minimax vision describe (--image <path-or-url> | --file-id <id>) [flags]
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--image <path-or-url>` | string | Local path or URL (auto base64-encoded) |
+| `--file-id <id>` | string | Pre-uploaded file ID (skips base64) |
+| `--prompt <text>` | string | Question about the image (default: `"Describe the image."`) |
+
+```bash
+minimax vision describe --image photo.jpg --prompt "What breed?" --output json
+```
+
+**stdout**: description text (text mode) or full response (json mode).
+
+---
+
+### search query
+
+Web search via MiniMax.
+
+```bash
+minimax search query --q <query>
+```
+
+| Flag | Type | Description |
+|---|---|---|
+| `--q <query>` | string, **required** | Search query |
+
+```bash
+minimax search query --q "MiniMax AI" --output json --quiet
+```
+
+---
+
+### quota show
+
+Display Token Plan usage and remaining quotas.
+
+```bash
+minimax quota show [--output json]
+```
+
+---
+
+## Tool Schema Export
+
+Export all commands as Anthropic/OpenAI-compatible JSON tool schemas:
+
+```bash
+# All tool-worthy commands (excludes auth/config/update)
+minimax config export-schema
+
+# Single command
+minimax config export-schema --command "video generate"
+```
+
+Use this to dynamically register minimax commands as tools in your agent framework.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error |
+| 2 | Usage error (bad flags, missing args) |
+| 3 | Authentication error |
+| 4 | Quota exceeded |
+| 5 | Timeout |
+| 10 | Content filter triggered |
+
+---
+
+## Piping Patterns
+
+```bash
+# stdout is always clean data — safe to pipe
+minimax text chat --message "Hi" --output json | jq '.content'
+
+# stderr has progress/spinners — discard if needed
+minimax video generate --prompt "Waves" 2>/dev/null
+
+# Chain: generate image → describe it
+URL=$(minimax image generate --prompt "A sunset" --quiet)
+minimax vision describe --image "$URL" --quiet
+
+# Async video workflow
+TASK=$(minimax video generate --prompt "A robot" --async --quiet | jq -r '.taskId')
+minimax video task get --task-id "$TASK" --output json
+minimax video download --task-id "$TASK" --out robot.mp4
+```
+
+---
+
+## Configuration Precedence
+
+CLI flags → environment variables → `~/.minimax/config.yaml` → defaults.
+
+```bash
+# Persistent config
+minimax config set --key region --value cn
+minimax config show
+
+# Environment
+export MINIMAX_API_KEY=sk-xxxxx
+export MINIMAX_REGION=cn
+```


### PR DESCRIPTION
## Summary
- Simplify README.md to essentials: intro, install, quick start, command table
- Add `skill/SKILL.md` as comprehensive agent integration guide with full command signatures, agent flags, exit codes, tool schema export, and piping patterns

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify skill/SKILL.md links and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)