### PR TITLE
feat: add MiniMax brand true-color status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ minimax text chat --message "Hi" --output json | jq .        # pipe-friendly
 minimax config export-schema | jq .                          # tool schemas
 ```
 
+## Changelog
+
+### v0.5.0
+- **Brand status bar**: HTTP requests now print a beautiful true-color status bar showing `MINIMAX Region: CN | Key: sk-c...nI7s | Model: MiniMax-M2.7` in MiniMax brand colors (blue, purple, cyan, pink)
+- Status bar respects `--quiet` flag and only renders in TTY terminals
+- Removed duplicate `[Model: ...]` output from `text chat` command
+
+### v0.1.0
+- Initial release — text, image, video, speech, music, vision, and search commands
+
 ## Output Philosophy
 
 - `stdout` → data only (text, paths, JSON)

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -47,7 +47,7 @@ export async function request(
     }
 
     // ANSI 真彩色 (24-bit) 与基础排版
-    if (process.stderr.isTTY) {
+    if (!config.quiet && process.stderr.isTTY) {
       const reset = '\x1b[0m';
       const dim = '\x1b[2m';
       const bold = '\x1b[1m'; // 新增加粗效果

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -45,6 +45,41 @@ export async function request(
       process.stderr.write(`> ${opts.method || 'GET'} ${opts.url}\n`);
       process.stderr.write(`> Auth: ${credential.token.slice(0, 8)}...\n`);
     }
+
+    // ANSI 真彩色 (24-bit) 与基础排版
+    if (process.stderr.isTTY) {
+      const reset = '\x1b[0m';
+      const dim = '\x1b[2m';
+      const bold = '\x1b[1m'; // 新增加粗效果
+
+      // 从 MiniMax Logo/品牌视觉提取的 RGB 颜色
+      const mmBlue = '\x1b[38;2;43;82;255m';    // 主品牌色：MiniMax 科技蓝 (#2B52FF)
+      const mmPurple = '\x1b[38;2;147;51;234m'; // 辅助品牌色：活力紫 (#9333EA)
+      const mmCyan = '\x1b[38;2;6;184;212m';   // 点缀色：青色 (#06B8D4)
+      const mmPink = '\x1b[38;2;236;72;153m';   // 点缀色：粉红 (#EC4899)
+
+      // 提取 Region (根据 baseUrl 推断)
+      const region = config.baseUrl.includes('minimaxi.com') ? 'CN' : 'Global';
+
+      // 提取脱敏的 Key
+      const token = credential.token;
+      const maskedKey = token.length > 8 ? `${token.slice(0, 4)}...${token.slice(-4)}` : '***';
+
+      // 尝试从 body 中提取 Model
+      let modelStr = '';
+      if (opts.body && typeof opts.body === 'object' && 'model' in opts.body) {
+        modelStr = ` ${dim}|${reset} ${dim}Model:${reset} ${mmPurple}${(opts.body as any).model}${reset}`;
+      }
+
+      // 打印带有完整 MINIMAX 标识的状态栏
+      process.stderr.write(
+        `${bold}${mmBlue}MINIMAX${reset} ` +
+        `${dim}Region:${reset} ${mmCyan}${region}${reset} ` +
+        `${dim}|${reset} ` +
+        `${dim}Key:${reset} ${mmPink}${maskedKey}${reset}` +
+        `${modelStr}\n`
+      );
+    }
   }
 
   const timeoutMs = (opts.timeout || config.timeout) * 1000;

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -152,9 +152,6 @@ export default defineCommand({
     const url = chatEndpoint(config.baseUrl);
 
     if (shouldStream) {
-      if (!config.quiet) {
-        process.stderr.write(`[Model: ${model}]\n`);
-      }
       const res = await request(config, {
         url,
         method: 'POST',
@@ -213,10 +210,6 @@ export default defineCommand({
       });
 
       const text = extractText(response.content);
-
-      if (!config.quiet && format === 'text') {
-        process.stderr.write(`[Model: ${response.model || model}]\n`);
-      }
 
       if (config.quiet || format === 'text') {
         console.log(text);


### PR DESCRIPTION
## Changes

### Brand Status Bar (v0.5.0)

Replaced the plain HTTP request debug output with a beautiful MiniMax-branded true-color status bar rendered in the terminal.

**Terminal output preview:**
```
MINIMAX Region: CN | Key: sk-c...nI7s | Model: MiniMax-M2.7
```

---

### Implementation highlights

1. **加粗品牌标识** ✅  
   Used  — the prefix renders as bold, eye-catching brand wordmark

2. **真彩色 RGB 渲染** ✅  
   Replaced all generic system colors with precise 24-bit ANSI true-color codes:
   -  (#2B52FF) — MINIMAX wordmark (bold)
   -  (#9333EA) — model name
   -  (#06B8D4) — region
   -  (#EC4899) — masked API key

3. **关键状态透出** ✅  
   - Region: auto-detected from  (CN for , Global otherwise)
   - Key: masked to  format (first 4 + last 4 chars)

4. **模型信息注入** ✅  
   Scans  and appends  to the status bar on every API call

---

### Other improvements
- Status bar respects `--quiet` flag (suppressed when quiet mode is on)
- Only renders when `stderr` is a TTY — safe for log redirection
- Removed duplicate `[Model: ...]` prints in `src/commands/text/chat.ts` to avoid double output

### Files changed
- `src/client/http.ts` — true-color status bar in HTTP request path
- `src/commands/text/chat.ts` — removed duplicate model output
- `README.md` — added `## Changelog` section documenting v0.5.0