### PR TITLE
fix: add resetStatusBar() and fix test state pollution

### DIFF
--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -19,6 +19,14 @@ export interface RequestOpts {
 // Printed once per process invocation to avoid repeating on every request.
 let statusBarPrinted = false;
 
+/**
+ * Reset the status bar flag — for use in test afterEach hooks to prevent
+ * state pollution between test files.
+ */
+export function resetStatusBar(): void {
+  statusBarPrinted = false;
+}
+
 export async function request(
   config: Config,
   opts: RequestOpts,

--- a/test/client/http.test.ts
+++ b/test/client/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { requestJson } from '../../src/client/http';
+import { requestJson, resetStatusBar } from '../../src/client/http';
 import { createMockServer, jsonResponse, type MockServer } from '../helpers/mock-server';
 import type { Config } from '../../src/config/schema';
 
@@ -11,8 +11,8 @@ function makeConfig(baseUrl: string): Config {
     output: 'text',
     timeout: 10,
     verbose: false,
-    quiet: false,
-    noColor: false,
+    quiet: true,
+    noColor: true,
     yes: false,
     dryRun: false,
     nonInteractive: false,
@@ -25,6 +25,7 @@ describe('HTTP client', () => {
 
   afterEach(() => {
     server?.close();
+    resetStatusBar();
   });
 
   it('makes authenticated GET request', async () => {

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { resetStatusBar } from '../../../src/client/http';
 import { createMockServer, jsonResponse, sseResponse, type MockServer } from '../../helpers/mock-server';
 import textChatResponse from '../../fixtures/text-chat-response.json';
 import type { Config } from '../../../src/config/schema';
@@ -8,6 +9,7 @@ describe('text chat command', () => {
 
   afterEach(() => {
     server?.close();
+    resetStatusBar();
   });
 
   it('sends chat request and gets response', async () => {
@@ -70,7 +72,7 @@ describe('text chat command', () => {
       output: 'json',
       timeout: 10,
       verbose: false,
-      quiet: false,
+      quiet: true,
       noColor: true,
       yes: false,
       dryRun: true,
@@ -85,7 +87,7 @@ describe('text chat command', () => {
     try {
       await chatCommand.execute(config, {
         message: ['Hello'],
-        quiet: false,
+        quiet: true,
         verbose: false,
         noColor: true,
         yes: false,

--- a/test/commands/video/task-get.test.ts
+++ b/test/commands/video/task-get.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { resetStatusBar } from '../../../src/client/http';
 import { default as taskGetCommand } from '../../../src/commands/video/task-get';
 import { createMockServer, jsonResponse, type MockServer } from '../../helpers/mock-server';
 import videoTaskSuccess from '../../fixtures/video-task-success.json';
@@ -8,6 +9,7 @@ describe('video task get command', () => {
 
   afterEach(() => {
     server?.close();
+    resetStatusBar();
   });
 
   it('has correct name', () => {


### PR DESCRIPTION
## Summary
Fixes test flakiness caused by the module-level `statusBarPrinted` flag in `src/client/http.ts`.

## Changes
- **src/client/http.ts**: Export a new `resetStatusBar()` function that resets `statusBarPrinted` to `false`. Call this in test `afterEach` hooks to prevent state from leaking between test files.
- **test/client/http.test.ts**: Import `resetStatusBar()`, add `afterEach` call, set `quiet: true` and `noColor: true` on all configs (was `quiet: false`).
- **test/commands/text/chat.test.ts**: Same `resetStatusBar()` import + `afterEach`, fix dry-run test config `quiet: false → true`.
- **test/commands/video/task-get.test.ts**: Same `resetStatusBar()` import + `afterEach`. Config kept `quiet: false` — that test exercises a known command bug (stdout/json mixing) that belongs in a separate PR.

All 62 tests pass.