### PR TITLE
fix: speech/music URL mode returns empty output (no --out)

### DIFF
--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -98,8 +98,8 @@ export default defineCommand({
       process.stderr.write('[Model: music-2.5]\n');
     }
 
-    if (outPath && response.data.audio) {
-      const audioBuffer = Buffer.from(response.data.audio, 'hex');
+    if (outPath) {
+      const audioBuffer = Buffer.from(response.data.audio!, 'hex');
       writeFileSync(outPath, audioBuffer);
 
       if (config.quiet) {
@@ -112,12 +112,13 @@ export default defineCommand({
           sample_rate: response.extra_info?.audio_sample_rate,
         }, format));
       }
-    } else if (response.data.audio_url) {
+    } else {
+      const audioUrl = response.data.audio_url ?? response.data.audio;
       if (config.quiet) {
-        console.log(response.data.audio_url);
+        console.log(audioUrl);
       } else {
         console.log(formatOutput({
-          url: response.data.audio_url,
+          url: audioUrl,
           duration_ms: response.extra_info?.audio_length,
           size_bytes: response.extra_info?.audio_size,
         }, format));

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -121,9 +121,9 @@ export default defineCommand({
       process.stderr.write(`[Model: ${model}]\n`);
     }
 
-    if (outPath && response.data.audio) {
-      // --out given: decode hex and save to file
-      const audioBuffer = Buffer.from(response.data.audio, 'hex');
+    if (outPath) {
+      // output_format='hex': data.audio is hex-encoded binary
+      const audioBuffer = Buffer.from(response.data.audio!, 'hex');
       writeFileSync(outPath, audioBuffer);
 
       if (config.quiet) {
@@ -136,13 +136,14 @@ export default defineCommand({
           sample_rate: response.extra_info?.audio_sample_rate,
         }, format));
       }
-    } else if (response.data.audio_url) {
-      // No --out: return URL
+    } else {
+      // output_format='url': API returns URL in data.audio (not data.audio_url)
+      const audioUrl = response.data.audio_url ?? response.data.audio;
       if (config.quiet) {
-        console.log(response.data.audio_url);
+        console.log(audioUrl);
       } else {
         console.log(formatOutput({
-          url: response.data.audio_url,
+          url: audioUrl,
           duration_ms: response.extra_info?.audio_length,
           size_bytes: response.extra_info?.audio_size,
         }, format));


### PR DESCRIPTION
## Summary

- `speech synthesize` 和 `music generate` 在不指定 `--out` 时（URL 模式）静默无输出

## Root Cause

API 在 `output_format:'url'` 时把 URL 放在 `data.audio` 字段，而不是 `data.audio_url`。原代码检查 `data.audio_url`（始终为空），导致两个 else 分支都未命中，stdout 无输出。

## Fix

以 `outPath` 是否存在判断解码模式，不依赖响应字段名：
- `outPath` 存在 → `output_format:'hex'`，`data.audio` 是 hex 二进制，decode 后写文件
- `outPath` 不存在 → `output_format:'url'`，取 `data.audio_url ?? data.audio` 作为 URL 输出

## Test

```bash
minimax speech synthesize --text "Hello" --quiet   # 输出 https://... URL ✅
minimax speech synthesize --text "Hello" --out /tmp/a.mp3  # 保存文件 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)