### PR TITLE
docs: rewrite README + add README_CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,181 @@
 # minimax-cli
 
-CLI for the [MiniMax AI Platform](https://platform.minimax.io) — generate text, images, video, speech, and music from the terminal. Supports **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) with automatic region detection.
+CLI for the [MiniMax AI Platform](https://platform.minimax.io) — generate text, images, video, speech, and music from the terminal.
 
----
+Supports **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) with automatic region detection.
 
-### Why minimax-cli?
-
-Zero-config Agent integration — `minimax config export-schema` dumps a standard Anthropic/OpenAI-compatible JSON Tool Schema in one shot. Cursor, Cline, Dify, and any other Agent framework that speaks tool schemas can start using all minimax commands instantly.
-
-Pipeline & CI friendly — all data flows through `stdout`, every piece of UI (spinners, status bars, progress bars) stays on `stderr`. `minimax text chat --message "hi" | jq .` Just Works™ — no stray ANSI codes, no mixed streams.
-
-Polished terminal experience — every invocation shows a branded dashboard with live quota balance and a real-color status bar exposing region, key source, and active model. Because how you look matters in the shell.
+[中文文档](README_CN.md)
 
 ---
 
 ## Install
 
+**Binary (recommended) — macOS / Linux / Windows:**
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/minimax-cli/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/cli/main/install.sh | sh
 ```
 
-Or via npm / bun:
+**npm / bun:**
 
 ```bash
 npm install -g minimax-cli
 ```
 
+---
+
 ## Quick Start
 
 ```bash
 minimax auth login --api-key sk-xxxxx
+
 minimax text chat --message "What is MiniMax?"
-minimax image generate --prompt "A cat in a spacesuit"
-minimax video generate --prompt "Ocean waves at sunset"
+minimax image "A cat in a spacesuit"
 minimax speech synthesize --text "Hello!" --out hello.mp3
-minimax music generate --prompt "Indie folk" --lyrics "La la la..."
-minimax vision describe --image photo.jpg
-minimax search query --q "MiniMax AI latest news"
+minimax search "MiniMax AI latest news"
+minimax vision photo.jpg
+minimax quota
 ```
+
+---
 
 ## Commands
 
-| Command | Description |
-|---|---|
-| `text chat` | Chat completion (MiniMax-M2.7) |
-| `image generate` | Image generation (image-01) |
-| `video generate` | Video generation (Hailuo-2.3) |
-| `speech synthesize` | Text-to-speech (speech-2.8-hd) |
-| `music generate` | Music generation (music-2.5) |
-| `vision describe` | Image understanding (VLM) |
-| `search query` | Web search |
-| `quota show` | Usage quotas |
-| `config show / set` | Configuration |
-| `config export-schema` | Export tool schemas as JSON |
-| `auth login/status/refresh/logout` | Authentication |
-| `update` | Self-update |
-
-Run `minimax <command> --help` for full options.
-
-## Agent / CI Usage
-
-See [skill/SKILL.md](skill/SKILL.md) for the complete agent integration guide, including all command signatures, tool schema export, and piping patterns.
+### Text
 
 ```bash
-minimax video generate --prompt "A robot." --async --quiet   # non-blocking
-minimax text chat --message "Hi" --output json | jq .        # pipe-friendly
-minimax config export-schema | jq .                          # tool schemas
+minimax text chat --message "Write a poem"
+minimax text chat --model MiniMax-M2.7-highspeed --message "Hello" --stream
+minimax text chat --system "You are a coding assistant" --message "Fizzbuzz in Go"
+minimax text chat --message "user:Hi" --message "assistant:Hey!" --message "How are you?"
+cat messages.json | minimax text chat --messages-file - --output json
 ```
 
-## Changelog
+### Image
 
-### v0.5.0
-- **Brand status bar**: HTTP requests now print a beautiful true-color status bar showing `MINIMAX Region: CN | Key: sk-c...nI7s | Model: MiniMax-M2.7` in MiniMax brand colors (blue, purple, cyan, pink)
-- Status bar respects `--quiet` flag and only renders in TTY terminals
-- Removed duplicate `[Model: ...]` output from `text chat` command
+```bash
+minimax image "A cat in a spacesuit"              # shorthand
+minimax image generate --prompt "A cat" --n 3 --aspect-ratio 16:9
+minimax image generate --prompt "Logo" --out-dir ./out/
+```
 
-### v0.1.0
-- Initial release — text, image, video, speech, music, vision, and search commands
+### Video
+
+```bash
+minimax video generate --prompt "Ocean waves at sunset" --async
+minimax video generate --prompt "A robot painting" --download sunset.mp4
+minimax video task get --task-id 123456
+minimax video download --file-id 176844028768320 --out video.mp4
+```
+
+### Speech
+
+```bash
+minimax speech synthesize --text "Hello!" --out hello.mp3
+minimax speech synthesize --text "Stream me" --stream | mpv -
+minimax speech synthesize --text "Hi" --voice Boyan_new_hailuo --speed 1.2
+echo "Breaking news" | minimax speech synthesize --text-file - --out news.mp3
+minimax speech voices
+```
+
+### Music
+
+```bash
+minimax music "Upbeat pop"                        # shorthand
+minimax music generate --prompt "Jazz" --lyrics "La la la" --out song.mp3
+```
+
+### Vision
+
+```bash
+minimax vision photo.jpg                          # shorthand
+minimax vision describe --image https://example.com/img.jpg --prompt "What breed?"
+minimax vision describe --file-id file-123
+```
+
+### Search
+
+```bash
+minimax search "MiniMax AI"                       # shorthand
+minimax search query --q "latest news" --output json
+```
+
+### Quota & Config
+
+```bash
+minimax quota
+minimax config show
+minimax config set --key region --value cn
+minimax config export-schema | jq .
+```
+
+### Auth
+
+```bash
+minimax auth login --api-key sk-xxxxx
+minimax auth login                    # OAuth browser flow
+minimax auth status
+minimax auth refresh
+minimax auth logout
+```
+
+### Update
+
+```bash
+minimax update
+minimax update latest
+```
+
+---
+
+## Global Flags
+
+| Flag | Description |
+|---|---|
+| `--api-key <key>` | API key (overrides config) |
+| `--region <global\|cn>` | API region |
+| `--output <text\|json\|yaml>` | Output format |
+| `--quiet` | Data only on stdout, no decorations |
+| `--verbose` | Print HTTP request/response |
+| `--dry-run` | Show request body, no API call |
+| `--async` | Return task ID immediately (video) |
+| `--non-interactive` | Disable prompts (CI/agent mode) |
+| `--timeout <seconds>` | Request timeout (default: 300) |
+| `--no-color` | Disable ANSI colors |
+
+Add `--help` to any command for full options.
+
+---
+
+## Agent / CI Integration
+
+Export all commands as JSON Tool Schema in one shot:
+
+```bash
+minimax config export-schema | jq .
+minimax config export-schema --command "text chat"
+```
+
+Compatible with Cursor, Cline, Dify, and any framework that speaks Anthropic/OpenAI tool schemas. See [skill/SKILL.md](skill/SKILL.md) for the full integration guide.
+
+**Piping:**
+
+```bash
+minimax text chat --message "Hello" --output json | jq .content
+minimax image "A logo" --quiet | xargs curl -O
+minimax video generate --prompt "A robot" --async --quiet
+```
+
+stdout is always clean data. stderr carries all UI (status bar, spinners, progress).
+
+---
 
 ## Output Philosophy
 
-- `stdout` → data only (text, paths, JSON)
-- `stderr` → spinners, warnings, help
+- `stdout` → data only (text, URLs, JSON, raw audio bytes)
+- `stderr` → status bar, progress, warnings, help
+
+---
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,182 @@
+# minimax-cli
+
+[MiniMax AI 开放平台](https://platform.minimaxi.com) 的命令行工具——在终端生成文字、图像、视频、语音和音乐。
+
+支持**国际版**（`api.minimax.io`）和**国内版**（`api.minimaxi.com`），自动识别区域。
+
+[English](README.md)
+
+---
+
+## 安装
+
+**二进制安装（推荐）— macOS / Linux / Windows：**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/cli/main/install.sh | sh
+```
+
+**npm / bun：**
+
+```bash
+npm install -g minimax-cli
+```
+
+---
+
+## 快速开始
+
+```bash
+minimax auth login --api-key sk-xxxxx
+
+minimax text chat --message "你好，MiniMax！"
+minimax image "一只穿宇航服的猫"
+minimax speech synthesize --text "你好！" --out hello.mp3
+minimax search "MiniMax AI 最新动态"
+minimax vision photo.jpg
+minimax quota
+```
+
+---
+
+## 命令参考
+
+### 文本对话
+
+```bash
+minimax text chat --message "写一首诗"
+minimax text chat --model MiniMax-M2.7-highspeed --message "你好" --stream
+minimax text chat --system "你是编程助手" --message "用 Go 写 Fizzbuzz"
+minimax text chat --message "user:你好" --message "assistant:嗨！" --message "你叫什么名字？"
+cat messages.json | minimax text chat --messages-file - --output json
+```
+
+### 图像生成
+
+```bash
+minimax image "一只穿宇航服的猫"                    # 简写
+minimax image generate --prompt "科技感 Logo" --n 3 --aspect-ratio 16:9
+minimax image generate --prompt "山水画" --out-dir ./output/
+```
+
+### 视频生成
+
+```bash
+minimax video generate --prompt "海浪拍打礁石" --async
+minimax video generate --prompt "机器人作画" --download sunset.mp4
+minimax video task get --task-id 123456
+minimax video download --file-id 176844028768320 --out video.mp4
+```
+
+### 语音合成
+
+```bash
+minimax speech synthesize --text "你好！" --out hello.mp3
+minimax speech synthesize --text "流式输出" --stream | mpv -
+minimax speech synthesize --text "Hi" --voice Boyan_new_hailuo --speed 1.2
+echo "头条新闻" | minimax speech synthesize --text-file - --out news.mp3
+minimax speech voices                             # 列出可用音色
+```
+
+### 音乐生成
+
+```bash
+minimax music "欢快的流行乐"                         # 简写
+minimax music generate --prompt "爵士风" --lyrics "啦啦啦" --out song.mp3
+```
+
+### 图像理解
+
+```bash
+minimax vision photo.jpg                          # 简写
+minimax vision describe --image https://example.com/img.jpg --prompt "这是什么品种的狗？"
+minimax vision describe --file-id file-123
+```
+
+### 网络搜索
+
+```bash
+minimax search "MiniMax AI"                       # 简写
+minimax search query --q "最新动态" --output json
+```
+
+### 配额与配置
+
+```bash
+minimax quota                                     # 查看配额用量
+minimax config show
+minimax config set --key region --value cn
+minimax config export-schema | jq .
+```
+
+### 认证
+
+```bash
+minimax auth login --api-key sk-xxxxx             # API Key 登录
+minimax auth login                                # OAuth 浏览器授权
+minimax auth status
+minimax auth refresh
+minimax auth logout
+```
+
+### 更新
+
+```bash
+minimax update
+minimax update latest
+```
+
+---
+
+## 全局 Flag
+
+| Flag | 说明 |
+|---|---|
+| `--api-key <key>` | API Key（覆盖配置文件） |
+| `--region <global\|cn>` | 接口区域 |
+| `--output <text\|json\|yaml>` | 输出格式 |
+| `--quiet` | 只输出数据，无装饰信息 |
+| `--verbose` | 打印 HTTP 请求/响应详情 |
+| `--dry-run` | 展示请求体，不发起 API 调用 |
+| `--async` | 立即返回任务 ID（视频异步模式） |
+| `--non-interactive` | 禁用交互提示（CI/Agent 模式） |
+| `--timeout <秒>` | 请求超时（默认 300 秒） |
+| `--no-color` | 关闭 ANSI 颜色 |
+
+任意命令后加 `--help` 查看完整参数。
+
+---
+
+## Agent / CI 集成
+
+一键导出所有命令的 JSON Tool Schema：
+
+```bash
+minimax config export-schema | jq .
+minimax config export-schema --command "text chat"
+```
+
+兼容 Cursor、Cline、Dify 等任何支持 Anthropic/OpenAI Tool Schema 的 Agent 框架。完整集成指南见 [skill/SKILL.md](skill/SKILL.md)。
+
+**管道用法：**
+
+```bash
+minimax text chat --message "你好" --output json | jq .content
+minimax image "Logo" --quiet | xargs curl -O
+minimax video generate --prompt "机器人" --async --quiet
+```
+
+stdout 始终是纯净数据，stderr 承载所有 UI（状态栏、进度、警告）。
+
+---
+
+## 输出规范
+
+- `stdout` → 纯数据（文字、URL、JSON、原始音频字节流）
+- `stderr` → 状态栏、进度条、警告、帮助信息
+
+---
+
+## 许可证
+
+MIT


### PR DESCRIPTION
## Summary

- **README.md**: 重写为以示例为核心的结构，补充简写语法（`minimax image "prompt"`），修正 install URL 为 `MiniMax-AI-Dev/cli`，移除过时 changelog，顶部添加 EN/CN 互跳链接
- **README_CN.md**: 完整中文版，国内平台链接（minimaxi.com）

## Preview

```bash
# 简写
minimax image "一只穿宇航服的猫"
minimax search "MiniMax AI 最新动态"
minimax vision photo.jpg
minimax quota
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)