### PR TITLE
feat: welcome screen + trim global flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,55 +128,6 @@ minimax update latest
 
 ---
 
-## Global Flags
-
-| Flag | Description |
-|---|---|
-| `--api-key <key>` | API key (overrides config) |
-| `--region <global\|cn>` | API region |
-| `--output <text\|json\|yaml>` | Output format |
-| `--quiet` | Data only on stdout, no decorations |
-| `--verbose` | Print HTTP request/response |
-| `--dry-run` | Show request body, no API call |
-| `--async` | Return task ID immediately (video) |
-| `--non-interactive` | Disable prompts (CI/agent mode) |
-| `--timeout <seconds>` | Request timeout (default: 300) |
-| `--no-color` | Disable ANSI colors |
-
-Add `--help` to any command for full options.
-
----
-
-## Agent / CI Integration
-
-Export all commands as JSON Tool Schema in one shot:
-
-```bash
-minimax config export-schema | jq .
-minimax config export-schema --command "text chat"
-```
-
-Compatible with Cursor, Cline, Dify, and any framework that speaks Anthropic/OpenAI tool schemas. See [skill/SKILL.md](skill/SKILL.md) for the full integration guide.
-
-**Piping:**
-
-```bash
-minimax text chat --message "Hello" --output json | jq .content
-minimax image "A logo" --quiet | xargs curl -O
-minimax video generate --prompt "A robot" --async --quiet
-```
-
-stdout is always clean data. stderr carries all UI (status bar, spinners, progress).
-
----
-
-## Output Philosophy
-
-- `stdout` → data only (text, URLs, JSON, raw audio bytes)
-- `stderr` → status bar, progress, warnings, help
-
----
-
 ## License
 
 MIT

--- a/README_CN.md
+++ b/README_CN.md
@@ -128,55 +128,6 @@ minimax update latest
 
 ---
 
-## 全局 Flag
-
-| Flag | 说明 |
-|---|---|
-| `--api-key <key>` | API Key（覆盖配置文件） |
-| `--region <global\|cn>` | 接口区域 |
-| `--output <text\|json\|yaml>` | 输出格式 |
-| `--quiet` | 只输出数据，无装饰信息 |
-| `--verbose` | 打印 HTTP 请求/响应详情 |
-| `--dry-run` | 展示请求体，不发起 API 调用 |
-| `--async` | 立即返回任务 ID（视频异步模式） |
-| `--non-interactive` | 禁用交互提示（CI/Agent 模式） |
-| `--timeout <秒>` | 请求超时（默认 300 秒） |
-| `--no-color` | 关闭 ANSI 颜色 |
-
-任意命令后加 `--help` 查看完整参数。
-
----
-
-## Agent / CI 集成
-
-一键导出所有命令的 JSON Tool Schema：
-
-```bash
-minimax config export-schema | jq .
-minimax config export-schema --command "text chat"
-```
-
-兼容 Cursor、Cline、Dify 等任何支持 Anthropic/OpenAI Tool Schema 的 Agent 框架。完整集成指南见 [skill/SKILL.md](skill/SKILL.md)。
-
-**管道用法：**
-
-```bash
-minimax text chat --message "你好" --output json | jq .content
-minimax image "Logo" --quiet | xargs curl -O
-minimax video generate --prompt "机器人" --async --quiet
-```
-
-stdout 始终是纯净数据，stderr 承载所有 UI（状态栏、进度、警告）。
-
----
-
-## 输出规范
-
-- `stdout` → 纯数据（文字、URL、JSON、原始音频字节流）
-- `stderr` → 状态栏、进度条、警告、帮助信息
-
----
-
 ## 许可证
 
 MIT

--- a/src/command.ts
+++ b/src/command.ts
@@ -47,10 +47,8 @@ export const GLOBAL_OPTIONS: OptionDef[] = [
   { flag: '--quiet',             description: 'Suppress non-essential output' },
   { flag: '--verbose',           description: 'Print HTTP request/response details' },
   { flag: '--no-color',          description: 'Disable ANSI colors' },
-  { flag: '--yes',               description: 'Skip confirmation prompts' },
   { flag: '--dry-run',           description: 'Dry run mode' },
   { flag: '--non-interactive',   description: 'Disable interactive prompts' },
-  { flag: '--async',             description: 'Return task ID immediately' },
   { flag: '--help',              description: 'Show help' },
   { flag: '--version',           description: 'Print version' },
 ];

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -8,6 +8,9 @@ export default defineCommand({
   name: 'auth logout',
   description: 'Revoke tokens and clear stored credentials',
   usage: 'minimax auth logout [--yes] [--dry-run]',
+  options: [
+    { flag: '--yes', description: 'Skip confirmation prompt' },
+  ],
   examples: [
     'minimax auth logout',
     'minimax auth logout --dry-run',

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,10 @@ async function main() {
     process.exit(0);
   }
 
-  // No command: show quota if logged in, else guide to login
+  // No command: help + quota (if logged in) or login guide
   if (commandPath.length === 0) {
+    registry.printHelp([], process.stderr);
+
     const { command: quotaCmd } = registry.resolve(['quota', 'show']);
     const flags = parseFlags(argv, [...GLOBAL_OPTIONS, ...(quotaCmd.options ?? [])]);
     const config = loadConfig(flags);
@@ -37,7 +39,7 @@ async function main() {
     if (hasKey || hasOAuth) {
       await quotaCmd.execute(config, flags);
     } else {
-      process.stderr.write('\n  Not logged in.\n\n');
+      process.stderr.write('  Not logged in.\n');
       process.stderr.write('  minimax auth login --api-key sk-xxxxx\n\n');
     }
     process.exit(0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { loadConfig } from './config/loader';
 import { detectRegion, saveDetectedRegion } from './config/detect-region';
 import { REGIONS } from './config/schema';
 import { checkForUpdate, getPendingUpdateNotification } from './update/checker';
+import { loadCredentials } from './auth/credentials';
 
 const CLI_VERSION = process.env.CLI_VERSION ?? '0.3.1';
 
@@ -17,15 +18,31 @@ async function main() {
     process.exit(0);
   }
 
-  // Pass 1: find command path from positional args
   const commandPath = scanCommandPath(argv);
 
-  if (argv.includes('--help') || argv.includes('-h') || commandPath.length === 0) {
+  if (argv.includes('--help') || argv.includes('-h')) {
     registry.printHelp(commandPath, process.stderr);
     process.exit(0);
   }
 
-  // Pass 2: resolve command, then parse flags with the merged schema
+  // No command: show quota if logged in, else guide to login
+  if (commandPath.length === 0) {
+    const { command: quotaCmd } = registry.resolve(['quota', 'show']);
+    const flags = parseFlags(argv, [...GLOBAL_OPTIONS, ...(quotaCmd.options ?? [])]);
+    const config = loadConfig(flags);
+
+    const hasKey = !!(config.apiKey || config.envApiKey || config.fileApiKey);
+    const hasOAuth = !!(await loadCredentials());
+
+    if (hasKey || hasOAuth) {
+      await quotaCmd.execute(config, flags);
+    } else {
+      process.stderr.write('\n  Not logged in.\n\n');
+      process.stderr.write('  minimax auth login --api-key sk-xxxxx\n\n');
+    }
+    process.exit(0);
+  }
+
   const { command, extra } = registry.resolve(commandPath);
   const flags = parseFlags(argv, [...GLOBAL_OPTIONS, ...(command.options ?? [])]);
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -165,10 +165,8 @@ Global Flags:
   --verbose              Print HTTP request/response details
   --timeout <seconds>    Request timeout (default: 300)
   --no-color             Disable ANSI colors and spinners
-  --yes                  Skip confirmation prompts
   --dry-run              Show what would happen without executing
   --non-interactive      Disable interactive prompts (CI/agent mode)
-  --async                Return task ID immediately without polling
   --version              Print version and exit
   --help                 Show help
 


### PR DESCRIPTION
## Summary

- **`minimax`（无参数）**: 先输出 help，再紧跟 quota 面板（已登录）或登录引导（未登录）
- **GLOBAL_OPTIONS 瘦身**: 移除 `--yes`（归还 `auth logout`）和 `--async`（已在 `video generate`），全局 flag 从 14 个减至 12 个
- **README / README_CN**: 删掉 Global Flags 表、Agent/CI Integration、Output Philosophy 三段

## Behavior

```
$ minimax
[help text]
[quota HUD]        ← logged in

$ minimax          ← not logged in
[help text]
  Not logged in.
  minimax auth login --api-key sk-xxxxx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)