### PR TITLE
docs: remove npm/bun install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,8 @@ Supports **Global** (`api.minimax.io`) and **CN** (`api.minimaxi.com`) with auto
 
 ## Install
 
-**Binary (recommended) — macOS / Linux / Windows:**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/cli/main/install.sh | sh
-```
-
-**npm / bun:**
-
-```bash
-npm install -g minimax-cli
 ```
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,16 +10,8 @@
 
 ## 安装
 
-**二进制安装（推荐）— macOS / Linux / Windows：**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/cli/main/install.sh | sh
-```
-
-**npm / bun：**
-
-```bash
-npm install -g minimax-cli
 ```
 
 ---


### PR DESCRIPTION
不支持 npm 发布，删除 README 和 README_CN 中的 npm/bun 安装方式，只保留 curl 二进制安装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)