### PR TITLE
refactor: store config as JSON instead of YAML

### DIFF
--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -20,7 +20,7 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
 
   // 3. API key from config file
   if (config.fileApiKey) {
-    return { token: config.fileApiKey, method: 'api-key', source: 'config.yaml' };
+    return { token: config.fileApiKey, method: 'api-key', source: 'config.json' };
   }
 
   // 4. Environment variable

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -77,7 +77,7 @@ export default defineCommand({
           );
         }
 
-        // Store key in config.yaml
+        // Store key in config.json
         const existing = readConfigFile() as Record<string, unknown>;
         existing.api_key = key;
         await writeConfigFile(existing);

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -23,7 +23,7 @@ export default defineCommand({
 
     if (config.dryRun) {
       if (creds) console.log('Would remove ~/.minimax/credentials.json');
-      if (hasConfigKey) console.log('Would clear api_key from ~/.minimax/config.yaml');
+      if (hasConfigKey) console.log('Would clear api_key from ~/.minimax/config.json');
       if (!creds && !hasConfigKey) console.log('No credentials to clear.');
       console.log('No changes made.');
       return;
@@ -39,7 +39,7 @@ export default defineCommand({
         const updated = fileConfig as Record<string, unknown>;
         delete updated.api_key;
         await writeConfigFile(updated);
-        process.stderr.write('Cleared api_key from ~/.minimax/config.yaml\n');
+        process.stderr.write('Cleared api_key from ~/.minimax/config.json\n');
       } catch { /* ignore */ }
     }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,15 +1,33 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { parse as parseYaml, stringify as yamlStringify } from 'yaml';
+import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
 import { parseConfigFile, REGIONS, type Config, type ConfigFile, type Region } from './schema';
-import { ensureConfigDir, getConfigPath } from './paths';
+import { ensureConfigDir, getConfigPath, getLegacyConfigPath } from './paths';
 import { detectOutputFormat, type OutputFormat } from '../output/formatter';
 import type { GlobalFlags } from '../types/flags';
 
+function migrateLegacyConfig(): void {
+  const legacy = getLegacyConfigPath();
+  const current = getConfigPath();
+  if (existsSync(legacy) && !existsSync(current)) {
+    try {
+      // Parse YAML by hand — only need simple key: value pairs
+      const raw = readFileSync(legacy, 'utf-8');
+      const obj: Record<string, string> = {};
+      for (const line of raw.split('\n')) {
+        const m = line.match(/^(\w+):\s*(.+)$/);
+        if (m) obj[m[1]!] = m[2]!.trim();
+      }
+      writeFileSync(current, JSON.stringify(obj, null, 2) + '\n', { mode: 0o600 });
+      renameSync(legacy, legacy + '.bak');
+    } catch { /* silent */ }
+  }
+}
+
 export function readConfigFile(): ConfigFile {
+  migrateLegacyConfig();
   const path = getConfigPath();
   if (!existsSync(path)) return {};
   try {
-    return parseConfigFile(parseYaml(readFileSync(path, 'utf-8')));
+    return parseConfigFile(JSON.parse(readFileSync(path, 'utf-8')));
   } catch {
     return {};
   }
@@ -17,7 +35,7 @@ export function readConfigFile(): ConfigFile {
 
 export async function writeConfigFile(data: Record<string, unknown>): Promise<void> {
   await ensureConfigDir();
-  writeFileSync(getConfigPath(), yamlStringify(data), { mode: 0o600 });
+  writeFileSync(getConfigPath(), JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
 }
 
 export function loadConfig(flags: GlobalFlags): Config {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -8,6 +8,10 @@ export function getConfigDir(): string {
 }
 
 export function getConfigPath(): string {
+  return join(getConfigDir(), 'config.json');
+}
+
+export function getLegacyConfigPath(): string {
   return join(getConfigDir(), 'config.yaml');
 }
 


### PR DESCRIPTION
## Summary

配置文件从 `~/.minimax/config.yaml` 改为 `~/.minimax/config.json`。

- `getConfigPath()` 返回 `config.json`
- 读写换成 `JSON.parse` / `JSON.stringify`
- 首次运行自动迁移：旧 `config.yaml` 内容写入 `config.json`，原文件重命名为 `config.yaml.bak`
- `yaml` 包保留（仍用于 `--output yaml` 格式化输出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)