### PR TITLE
refactor: remove yaml package, drop --output yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "prepublishOnly": "bun run build:npm"
   },
   "dependencies": {
-    "@clack/prompts": "^0.7.0",
-    "yaml": "^2.7.1"
+    "@clack/prompts": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/src/command.ts
+++ b/src/command.ts
@@ -42,7 +42,7 @@ export const GLOBAL_OPTIONS: OptionDef[] = [
   { flag: '--api-key <key>',     description: 'API key' },
   { flag: '--region <region>',   description: 'API region: global, cn' },
   { flag: '--base-url <url>',    description: 'API base URL' },
-  { flag: '--output <format>',   description: 'Output format: text, json, yaml' },
+  { flag: '--output <format>',   description: 'Output format: text, json' },
   { flag: '--timeout <seconds>', description: 'Request timeout', type: 'number' },
   { flag: '--quiet',             description: 'Suppress non-essential output' },
   { flag: '--verbose',           description: 'Print HTTP request/response details' },

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -48,9 +48,9 @@ export default defineCommand({
       );
     }
 
-    if (key === 'output' && !['text', 'json', 'yaml'].includes(value)) {
+    if (key === 'output' && !['text', 'json'].includes(value)) {
       throw new CLIError(
-        `Invalid output format "${value}". Valid values: text, json, yaml`,
+        `Invalid output format "${value}". Valid values: text, json`,
         ExitCode.USAGE,
       );
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -10,12 +10,12 @@ export interface ConfigFile {
   region?: Region;
   region_key_fingerprint?: string;
   base_url?: string;
-  output?: 'text' | 'json' | 'yaml';
+  output?: 'text' | 'json';
   timeout?: number;
 }
 
 const VALID_REGIONS = new Set<string>(['global', 'cn']);
-const VALID_OUTPUTS = new Set<string>(['text', 'json', 'yaml']);
+const VALID_OUTPUTS = new Set<string>(['text', 'json']);
 
 export function parseConfigFile(raw: unknown): ConfigFile {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
@@ -38,7 +38,7 @@ export interface Config {
   fileApiKey?: string;
   region: Region;
   baseUrl: string;
-  output: 'text' | 'json' | 'yaml';
+  output: 'text' | 'json';
   timeout: number;
   verbose: boolean;
   quiet: boolean;

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -1,11 +1,10 @@
-import { stringify as yamlStringify } from 'yaml';
 import { formatText } from './text';
 import { formatJson } from './json';
 
-export type OutputFormat = 'text' | 'json' | 'yaml';
+export type OutputFormat = 'text' | 'json';
 
 export function detectOutputFormat(flagValue?: string): OutputFormat {
-  if (flagValue === 'json' || flagValue === 'yaml' || flagValue === 'text') {
+  if (flagValue === 'json' || flagValue === 'text') {
     return flagValue;
   }
   if (!process.stdout.isTTY) {
@@ -18,8 +17,6 @@ export function formatOutput(data: unknown, format: OutputFormat): string {
   switch (format) {
     case 'json':
       return formatJson(data);
-    case 'yaml':
-      return yamlStringify(data, { indent: 2 }).trimEnd();
     case 'text':
       return formatText(data);
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -168,7 +168,7 @@ Global Flags:
   --api-key <key>        API key (overrides all other auth)
   --region <region>      API region: global (default), cn
   --base-url <url>       API base URL (overrides region)
-  --output <format>      Output format: text, json, yaml
+  --output <format>      Output format: text, json
   --quiet                Suppress non-essential output
   --verbose              Print HTTP request/response details
   --timeout <seconds>    Request timeout (default: 300)

--- a/test/auth/resolver.test.ts
+++ b/test/auth/resolver.test.ts
@@ -49,7 +49,7 @@ describe('resolveCredential', () => {
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-from-file');
     expect(cred.method).toBe('api-key');
-    expect(cred.source).toBe('config.yaml');
+    expect(cred.source).toBe('config.json');
   });
 
   it('throws when no credentials found', async () => {
@@ -67,7 +67,7 @@ describe('resolveCredential', () => {
     const config = makeConfig({ fileApiKey: 'sk-file', envApiKey: 'sk-env' });
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-file');
-    expect(cred.source).toBe('config.yaml');
+    expect(cred.source).toBe('config.json');
   });
 
   it('env var is lowest priority', async () => {

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -7,11 +7,6 @@ describe('formatOutput', () => {
     expect(JSON.parse(result)).toEqual({ key: 'value' });
   });
 
-  it('formats YAML output', () => {
-    const result = formatOutput({ key: 'value' }, 'yaml');
-    expect(result).toContain('key: value');
-  });
-
   it('formats text output for objects', () => {
     const result = formatOutput({ name: 'test', status: 'ok' }, 'text');
     expect(result).toContain('name: test');


### PR DESCRIPTION
## Summary

完全移除 `yaml` 包，不再支持 `--output yaml`。

- `package.json`: 删除 `yaml` 依赖
- `OutputFormat`: `'text' | 'json'`（去掉 `'yaml'`）
- `formatter.ts`: 删除 yaml import 和 case
- `schema.ts`, `config/set.ts`, `command.ts`, `registry.ts`: 同步更新
- 测试: 删除 yaml 测试用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)