### PR TITLE
refactor: JSON-only config, remove yaml dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "minimax-cli",
       "dependencies": {
         "@clack/prompts": "^0.7.0",
-        "yaml": "^2.7.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -199,8 +198,6 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
-
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "prepublishOnly": "bun run build:npm"
   },
   "dependencies": {
-    "@clack/prompts": "^0.7.0",
-    "yaml": "^2.7.1"
+    "@clack/prompts": "^0.7.0"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -20,7 +20,7 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
 
   // 3. API key from config file
   if (config.fileApiKey) {
-    return { token: config.fileApiKey, method: 'api-key', source: 'config.yaml' };
+    return { token: config.fileApiKey, method: 'api-key', source: 'config.json' };
   }
 
   // 4. Environment variable

--- a/src/command.ts
+++ b/src/command.ts
@@ -42,7 +42,7 @@ export const GLOBAL_OPTIONS: OptionDef[] = [
   { flag: '--api-key <key>',     description: 'API key' },
   { flag: '--region <region>',   description: 'API region: global, cn' },
   { flag: '--base-url <url>',    description: 'API base URL' },
-  { flag: '--output <format>',   description: 'Output format: text, json, yaml' },
+  { flag: '--output <format>',   description: 'Output format: text, json' },
   { flag: '--timeout <seconds>', description: 'Request timeout', type: 'number' },
   { flag: '--quiet',             description: 'Suppress non-essential output' },
   { flag: '--verbose',           description: 'Print HTTP request/response details' },

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -77,7 +77,7 @@ export default defineCommand({
           );
         }
 
-        // Store key in config.yaml
+        // Store key in config.json
         const existing = readConfigFile() as Record<string, unknown>;
         existing.api_key = key;
         await writeConfigFile(existing);

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -23,7 +23,7 @@ export default defineCommand({
 
     if (config.dryRun) {
       if (creds) console.log('Would remove ~/.minimax/credentials.json');
-      if (hasConfigKey) console.log('Would clear api_key from ~/.minimax/config.yaml');
+      if (hasConfigKey) console.log('Would clear api_key from ~/.minimax/config.json');
       if (!creds && !hasConfigKey) console.log('No credentials to clear.');
       console.log('No changes made.');
       return;
@@ -39,7 +39,7 @@ export default defineCommand({
         const updated = fileConfig as Record<string, unknown>;
         delete updated.api_key;
         await writeConfigFile(updated);
-        process.stderr.write('Cleared api_key from ~/.minimax/config.yaml\n');
+        process.stderr.write('Cleared api_key from ~/.minimax/config.json\n');
       } catch { /* ignore */ }
     }
 

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -48,9 +48,9 @@ export default defineCommand({
       );
     }
 
-    if (key === 'output' && !['text', 'json', 'yaml'].includes(value)) {
+    if (key === 'output' && !['text', 'json'].includes(value)) {
       throw new CLIError(
-        `Invalid output format "${value}". Valid values: text, json, yaml`,
+        `Invalid output format "${value}". Valid values: text, json`,
         ExitCode.USAGE,
       );
     }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { parse as parseYaml, stringify as yamlStringify } from 'yaml';
 import { parseConfigFile, REGIONS, type Config, type ConfigFile, type Region } from './schema';
 import { ensureConfigDir, getConfigPath } from './paths';
 import { detectOutputFormat, type OutputFormat } from '../output/formatter';
@@ -9,7 +8,7 @@ export function readConfigFile(): ConfigFile {
   const path = getConfigPath();
   if (!existsSync(path)) return {};
   try {
-    return parseConfigFile(parseYaml(readFileSync(path, 'utf-8')));
+    return parseConfigFile(JSON.parse(readFileSync(path, 'utf-8')));
   } catch {
     return {};
   }
@@ -17,7 +16,7 @@ export function readConfigFile(): ConfigFile {
 
 export async function writeConfigFile(data: Record<string, unknown>): Promise<void> {
   await ensureConfigDir();
-  writeFileSync(getConfigPath(), yamlStringify(data), { mode: 0o600 });
+  writeFileSync(getConfigPath(), JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
 }
 
 export function loadConfig(flags: GlobalFlags): Config {
@@ -31,7 +30,6 @@ export function loadConfig(flags: GlobalFlags): Config {
   const cachedRegion = file.region;
   const region = (explicitRegion || cachedRegion || 'global') as Region;
 
-  // Re-detect if: no explicit region AND (no cached region OR key fingerprint changed)
   const activeKey = apiKey || fileApiKey || envApiKey;
   const keyFingerprint = activeKey ? activeKey.slice(0, 8) : undefined;
   const needsRegionDetection = !explicitRegion

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -8,7 +8,7 @@ export function getConfigDir(): string {
 }
 
 export function getConfigPath(): string {
-  return join(getConfigDir(), 'config.yaml');
+  return join(getConfigDir(), 'config.json');
 }
 
 export function getCredentialsPath(): string {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -10,12 +10,12 @@ export interface ConfigFile {
   region?: Region;
   region_key_fingerprint?: string;
   base_url?: string;
-  output?: 'text' | 'json' | 'yaml';
+  output?: 'text' | 'json';
   timeout?: number;
 }
 
 const VALID_REGIONS = new Set<string>(['global', 'cn']);
-const VALID_OUTPUTS = new Set<string>(['text', 'json', 'yaml']);
+const VALID_OUTPUTS = new Set<string>(['text', 'json']);
 
 export function parseConfigFile(raw: unknown): ConfigFile {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
@@ -38,7 +38,7 @@ export interface Config {
   fileApiKey?: string;
   region: Region;
   baseUrl: string;
-  output: 'text' | 'json' | 'yaml';
+  output: 'text' | 'json';
   timeout: number;
   verbose: boolean;
   quiet: boolean;

--- a/src/output/formatter.ts
+++ b/src/output/formatter.ts
@@ -1,11 +1,10 @@
-import { stringify as yamlStringify } from 'yaml';
 import { formatText } from './text';
 import { formatJson } from './json';
 
-export type OutputFormat = 'text' | 'json' | 'yaml';
+export type OutputFormat = 'text' | 'json';
 
 export function detectOutputFormat(flagValue?: string): OutputFormat {
-  if (flagValue === 'json' || flagValue === 'yaml' || flagValue === 'text') {
+  if (flagValue === 'json' || flagValue === 'text') {
     return flagValue;
   }
   if (!process.stdout.isTTY) {
@@ -18,8 +17,6 @@ export function formatOutput(data: unknown, format: OutputFormat): string {
   switch (format) {
     case 'json':
       return formatJson(data);
-    case 'yaml':
-      return yamlStringify(data, { indent: 2 }).trimEnd();
     case 'text':
       return formatText(data);
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -168,7 +168,7 @@ Global Flags:
   --api-key <key>        API key (overrides all other auth)
   --region <region>      API region: global (default), cn
   --base-url <url>       API base URL (overrides region)
-  --output <format>      Output format: text, json, yaml
+  --output <format>      Output format: text, json
   --quiet                Suppress non-essential output
   --verbose              Print HTTP request/response details
   --timeout <seconds>    Request timeout (default: 300)

--- a/test/auth/resolver.test.ts
+++ b/test/auth/resolver.test.ts
@@ -49,7 +49,7 @@ describe('resolveCredential', () => {
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-from-file');
     expect(cred.method).toBe('api-key');
-    expect(cred.source).toBe('config.yaml');
+    expect(cred.source).toBe('config.json');
   });
 
   it('throws when no credentials found', async () => {
@@ -67,7 +67,7 @@ describe('resolveCredential', () => {
     const config = makeConfig({ fileApiKey: 'sk-file', envApiKey: 'sk-env' });
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-file');
-    expect(cred.source).toBe('config.yaml');
+    expect(cred.source).toBe('config.json');
   });
 
   it('env var is lowest priority', async () => {

--- a/test/output/formatter.test.ts
+++ b/test/output/formatter.test.ts
@@ -7,11 +7,6 @@ describe('formatOutput', () => {
     expect(JSON.parse(result)).toEqual({ key: 'value' });
   });
 
-  it('formats YAML output', () => {
-    const result = formatOutput({ key: 'value' }, 'yaml');
-    expect(result).toContain('key: value');
-  });
-
   it('formats text output for objects', () => {
     const result = formatOutput({ name: 'test', status: 'ok' }, 'text');
     expect(result).toContain('name: test');


### PR DESCRIPTION
## Summary

- `~/.minimax/config.yaml` → `~/.minimax/config.json`
- `yaml` 包完全移除（bundle 从 126 模块降到 54 模块）
- `--output yaml` 选项移除，只保留 `text` / `json`
- 无兼容处理，直接切换

## Changed files

| File | Change |
|---|---|
| `config/paths.ts` | `config.json` |
| `config/loader.ts` | `JSON.parse` / `JSON.stringify` |
| `output/formatter.ts` | 去掉 yaml case 和 import |
| `config/schema.ts` | `OutputFormat = 'text' \| 'json'` |
| `package.json` | 移除 yaml 依赖 |
| tests | 同步更新 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)