### PR TITLE
feat: add minimax.mjs, prefer Node.js in install.sh

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -5,13 +5,13 @@ import { readFileSync, writeFileSync } from 'fs';
 const VERSION = process.env.VERSION ?? 'dev';
 
 const targets = [
-  { bunTarget: 'bun-linux-x64',         platform: 'linux-x64',        output: 'minimax-linux-x64',        archive: 'minimax-linux-x64.tar.gz' },
-  { bunTarget: 'bun-linux-x64-musl',    platform: 'linux-x64-musl',   output: 'minimax-linux-x64-musl',   archive: 'minimax-linux-x64-musl.tar.gz' },
-  { bunTarget: 'bun-linux-arm64',       platform: 'linux-arm64',      output: 'minimax-linux-arm64',      archive: 'minimax-linux-arm64.tar.gz' },
-  { bunTarget: 'bun-linux-arm64-musl',  platform: 'linux-arm64-musl', output: 'minimax-linux-arm64-musl', archive: 'minimax-linux-arm64-musl.tar.gz' },
-  { bunTarget: 'bun-darwin-x64',        platform: 'darwin-x64',       output: 'minimax-darwin-x64',       archive: 'minimax-darwin-x64.tar.gz' },
-  { bunTarget: 'bun-darwin-arm64',      platform: 'darwin-arm64',     output: 'minimax-darwin-arm64',     archive: 'minimax-darwin-arm64.tar.gz' },
-  { bunTarget: 'bun-windows-x64',       platform: 'windows-x64',      output: 'minimax-windows-x64.exe',  archive: 'minimax-windows-x64.zip' },
+  { bunTarget: 'bun-linux-x64',        platform: 'linux-x64',        output: 'minimax-linux-x64' },
+  { bunTarget: 'bun-linux-x64-musl',   platform: 'linux-x64-musl',   output: 'minimax-linux-x64-musl' },
+  { bunTarget: 'bun-linux-arm64',      platform: 'linux-arm64',      output: 'minimax-linux-arm64' },
+  { bunTarget: 'bun-linux-arm64-musl', platform: 'linux-arm64-musl', output: 'minimax-linux-arm64-musl' },
+  { bunTarget: 'bun-darwin-x64',       platform: 'darwin-x64',       output: 'minimax-darwin-x64' },
+  { bunTarget: 'bun-darwin-arm64',     platform: 'darwin-arm64',     output: 'minimax-darwin-arm64' },
+  { bunTarget: 'bun-windows-x64',      platform: 'windows-x64',      output: 'minimax-windows-x64.exe' },
 ];
 
 function sha256(path: string): string {
@@ -22,13 +22,14 @@ console.log(`Building minimax-cli ${VERSION}...\n`);
 
 const manifest: {
   version: string;
-  platforms: Record<string, { archive: string; checksum: string }>;
+  platforms: Record<string, { file: string; checksum: string }>;
 } = { version: VERSION, platforms: {} };
 
-for (const { bunTarget, platform, output, archive } of targets) {
+// Platform standalones
+for (const { bunTarget, platform, output } of targets) {
   const outPath = `dist/${output}`;
-  const archivePath = `dist/${archive}`;
   process.stdout.write(`  ${output}...`);
+
   await $`bun build src/main.ts \
     --compile \
     --minify \
@@ -36,17 +37,27 @@ for (const { bunTarget, platform, output, archive } of targets) {
     --outfile ${outPath} \
     --define "process.env.CLI_VERSION='${VERSION}'"`.quiet();
 
-  // Compress: tar.gz for unix, zip for windows
-  if (archive.endsWith('.zip')) {
-    await $`zip -j ${archivePath} ${outPath}`.quiet();
-  } else {
-    await $`tar -czf ${archivePath} -C dist ${output}`.quiet();
-  }
-
-  manifest.platforms[platform] = { archive, checksum: sha256(archivePath) };
+  manifest.platforms[platform] = { file: output, checksum: sha256(outPath) };
   console.log(' ✓');
 }
 
+// Node.js .mjs bundle (much smaller, requires node >= 18)
+process.stdout.write('  minimax.mjs...');
+const mjsPath = 'dist/minimax.mjs';
+
+await $`bun build src/main.ts \
+  --outfile ${mjsPath} \
+  --target node \
+  --minify \
+  --define "process.env.CLI_VERSION='${VERSION}'"`.quiet();
+
+// Prepend shebang so the file is directly executable
+const mjsContent = readFileSync(mjsPath);
+writeFileSync(mjsPath, Buffer.concat([Buffer.from('#!/usr/bin/env node\n'), mjsContent]));
+
+manifest.platforms['node'] = { file: 'minimax.mjs', checksum: sha256(mjsPath) };
+console.log(' ✓');
+
 writeFileSync('dist/manifest.json', JSON.stringify(manifest, null, 2));
 console.log('  manifest.json ✓');
-console.log(`\nDone. ${targets.length} archives in dist/`);
+console.log(`\nDone. ${targets.length + 1} builds in dist/`);

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ case "$CHANNEL" in
     ;;
 esac
 
-REPO="MiniMax-AI-Dev/minimax-cli"
+REPO="MiniMax-AI-Dev/cli"
 INSTALL_DIR="${MINIMAX_INSTALL_DIR:-$HOME/.local/bin}"
 
 # Dependency check: curl or wget
@@ -27,34 +27,45 @@ else
   echo "curl or wget is required." >&2; exit 1
 fi
 
-# Detect OS
-case "$(uname -s)" in
-  Darwin) OS="darwin" ;;
-  Linux)  OS="linux"  ;;
-  *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
-esac
-
-# Detect architecture
-case "$(uname -m)" in
-  x86_64|amd64) ARCH="x64"   ;;
-  arm64|aarch64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-esac
-
-# Rosetta 2: x64 shell on ARM Mac → use native arm64 binary
-if [ "$OS" = "darwin" ] && [ "$ARCH" = "x64" ]; then
-  if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
-    ARCH="arm64"
+# Prefer Node.js >= 18 (much smaller download, ~200KB vs ~57MB)
+USE_NODE=0
+if command -v node >/dev/null 2>&1; then
+  NODE_MAJOR=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
+  if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -ge 18 ] 2>/dev/null; then
+    USE_NODE=1
   fi
 fi
 
-# musl detection on Linux
-PLATFORM="${OS}-${ARCH}"
-if [ "$OS" = "linux" ]; then
-  if [ -f /lib/libc.musl-x86_64.so.1 ] || \
-     [ -f /lib/libc.musl-aarch64.so.1 ] || \
-     ldd /bin/ls 2>&1 | grep -q musl; then
-    PLATFORM="${OS}-${ARCH}-musl"
+if [ "$USE_NODE" = "0" ]; then
+  # Detect OS
+  case "$(uname -s)" in
+    Darwin) OS="darwin" ;;
+    Linux)  OS="linux"  ;;
+    *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+  esac
+
+  # Detect architecture
+  case "$(uname -m)" in
+    x86_64|amd64)  ARCH="x64"   ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+
+  # Rosetta 2: x64 shell on ARM Mac → use native arm64 binary
+  if [ "$OS" = "darwin" ] && [ "$ARCH" = "x64" ]; then
+    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+      ARCH="arm64"
+    fi
+  fi
+
+  # musl detection on Linux
+  PLATFORM="${OS}-${ARCH}"
+  if [ "$OS" = "linux" ]; then
+    if [ -f /lib/libc.musl-x86_64.so.1 ] || \
+       [ -f /lib/libc.musl-aarch64.so.1 ] || \
+       ldd /bin/ls 2>&1 | grep -q musl; then
+      PLATFORM="${OS}-${ARCH}-musl"
+    fi
   fi
 fi
 
@@ -78,13 +89,22 @@ if [ -z "$VERSION" ]; then
   echo "Failed to resolve version." >&2; exit 1
 fi
 
-echo "Installing minimax ${VERSION} for ${PLATFORM}..."
-
-# Fetch manifest and extract SHA256 (pure sh, no jq required)
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+# Fetch manifest and extract checksum
 MANIFEST=$(download "${BASE_URL}/manifest.json") || {
   echo "Failed to fetch manifest.json" >&2; exit 1
 }
+
+if [ "$USE_NODE" = "1" ]; then
+  PLATFORM="node"
+  DOWNLOAD_FILE="minimax.mjs"
+  echo "Installing minimax ${VERSION} (Node.js)..."
+else
+  DOWNLOAD_FILE="minimax-${PLATFORM}"
+  echo "Installing minimax ${VERSION} for ${PLATFORM}..."
+fi
+
 CHECKSUM=$(printf '%s' "$MANIFEST" | tr -d '\n' | \
   sed "s/.*\"${PLATFORM}\"[^}]*\"checksum\" *: *\"\([a-f0-9]*\)\".*/\1/")
 
@@ -92,11 +112,11 @@ if [ -z "$CHECKSUM" ] || [ "${#CHECKSUM}" -ne 64 ]; then
   echo "Platform '${PLATFORM}' not found in manifest." >&2; exit 1
 fi
 
-# Download binary to temp file
+# Download to temp file
 TMP=$(mktemp)
 trap 'rm -f "$TMP"' EXIT
 
-download_to "${BASE_URL}/minimax-${PLATFORM}" "$TMP" || {
+download_to "${BASE_URL}/${DOWNLOAD_FILE}" "$TMP" || {
   echo "Download failed." >&2; exit 1
 }
 


### PR DESCRIPTION
## Summary

| | 二进制 | .mjs |
|---|---|---|
| 大小 | ~57MB | **~112KB** |
| 依赖 | 无 | Node.js >= 18 |
| 启动 | 快 | 快 |

## 变更

**build.ts**
- 新增 Node.js .mjs 构建（`--target node --minify`），加 `#!/usr/bin/env node` shebang
- manifest `checksum` 改为对实际下载文件计算（原来是对 tar.gz 计算，存在不一致）
- 移除 tar.gz 归档（install.sh 直接下载文件）

**install.sh**
- 优先检测 `node >= 18`，有则下载 `minimax.mjs`（112KB）
- 无 Node.js 则走原有平台二进制逻辑
- 修正 REPO 路径为 `MiniMax-AI-Dev/cli`

## Install flow

```
curl | sh
  ├── node >= 18 found → download minimax.mjs (112KB) ✓
  └── no node          → download minimax-darwin-arm64 (57MB)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)