### PR TITLE
ci: fix release upload globs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/*.tar.gz
-            dist/*.zip
+            dist/minimax-*
+            dist/minimax.mjs
             dist/manifest.json
           generate_release_notes: true


### PR DESCRIPTION
`build.ts` 不再产出 `.tar.gz` / `.zip`，改为直接上传原始文件。旧的 glob `dist/*.tar.gz` 匹配不到任何文件，导致 release 只有 `manifest.json`。

改为：
\`\`\`
dist/minimax-*    # 平台二进制
dist/minimax.mjs  # Node.js 版本
dist/manifest.json
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)