### PR TITLE
refactor: Node.js only, drop platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
 
-      - name: Build all targets
+      - name: Build
         run: VERSION=${GITHUB_REF_NAME} bun run build.ts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/minimax-*
             dist/minimax.mjs
             dist/manifest.json
           generate_release_notes: true

--- a/build.ts
+++ b/build.ts
@@ -1,63 +1,27 @@
-import { $ } from 'bun';
 import { createHash } from 'crypto';
 import { readFileSync, writeFileSync } from 'fs';
 
 const VERSION = process.env.VERSION ?? 'dev';
-
-const targets = [
-  { bunTarget: 'bun-linux-x64',        platform: 'linux-x64',        output: 'minimax-linux-x64' },
-  { bunTarget: 'bun-linux-x64-musl',   platform: 'linux-x64-musl',   output: 'minimax-linux-x64-musl' },
-  { bunTarget: 'bun-linux-arm64',      platform: 'linux-arm64',      output: 'minimax-linux-arm64' },
-  { bunTarget: 'bun-linux-arm64-musl', platform: 'linux-arm64-musl', output: 'minimax-linux-arm64-musl' },
-  { bunTarget: 'bun-darwin-x64',       platform: 'darwin-x64',       output: 'minimax-darwin-x64' },
-  { bunTarget: 'bun-darwin-arm64',     platform: 'darwin-arm64',     output: 'minimax-darwin-arm64' },
-  { bunTarget: 'bun-windows-x64',      platform: 'windows-x64',      output: 'minimax-windows-x64.exe' },
-];
+const OUT = 'dist/minimax.mjs';
 
 function sha256(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-console.log(`Building minimax-cli ${VERSION}...\n`);
+console.log(`Building minimax-cli ${VERSION}...`);
 
-const manifest: {
-  version: string;
-  platforms: Record<string, { file: string; checksum: string }>;
-} = { version: VERSION, platforms: {} };
+await Bun.build({
+  entrypoints: ['src/main.ts'],
+  outdir: 'dist',
+  naming: 'minimax.mjs',
+  target: 'node',
+  minify: true,
+  define: { 'process.env.CLI_VERSION': JSON.stringify(VERSION) },
+});
 
-// Platform standalones
-for (const { bunTarget, platform, output } of targets) {
-  const outPath = `dist/${output}`;
-  process.stdout.write(`  ${output}...`);
+// Prepend shebang
+const content = readFileSync(OUT);
+writeFileSync(OUT, Buffer.concat([Buffer.from('#!/usr/bin/env node\n'), content]));
 
-  await $`bun build src/main.ts \
-    --compile \
-    --minify \
-    --target ${bunTarget} \
-    --outfile ${outPath} \
-    --define "process.env.CLI_VERSION='${VERSION}'"`.quiet();
-
-  manifest.platforms[platform] = { file: output, checksum: sha256(outPath) };
-  console.log(' ✓');
-}
-
-// Node.js .mjs bundle (much smaller, requires node >= 18)
-process.stdout.write('  minimax.mjs...');
-const mjsPath = 'dist/minimax.mjs';
-
-await $`bun build src/main.ts \
-  --outfile ${mjsPath} \
-  --target node \
-  --minify \
-  --define "process.env.CLI_VERSION='${VERSION}'"`.quiet();
-
-// Prepend shebang so the file is directly executable
-const mjsContent = readFileSync(mjsPath);
-writeFileSync(mjsPath, Buffer.concat([Buffer.from('#!/usr/bin/env node\n'), mjsContent]));
-
-manifest.platforms['node'] = { file: 'minimax.mjs', checksum: sha256(mjsPath) };
-console.log(' ✓');
-
-writeFileSync('dist/manifest.json', JSON.stringify(manifest, null, 2));
-console.log('  manifest.json ✓');
-console.log(`\nDone. ${targets.length + 1} builds in dist/`);
+writeFileSync('dist/manifest.json', JSON.stringify({ version: VERSION, checksum: sha256(OUT) }, null, 2));
+console.log(`Done. dist/minimax.mjs  ${(content.length / 1024).toFixed(0)}KB`);

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,15 @@ esac
 REPO="MiniMax-AI-Dev/cli"
 INSTALL_DIR="${MINIMAX_INSTALL_DIR:-$HOME/.local/bin}"
 
+# Require Node.js >= 18
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required. Install from https://nodejs.org" >&2; exit 1
+fi
+NODE_MAJOR=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
+if [ -z "$NODE_MAJOR" ] || [ "$NODE_MAJOR" -lt 18 ] 2>/dev/null; then
+  echo "Node.js 18+ is required (found: $(node --version))" >&2; exit 1
+fi
+
 # Dependency check: curl or wget
 if command -v curl >/dev/null 2>&1; then
   download()    { curl -fsSL "$1"; }
@@ -25,48 +34,6 @@ elif command -v wget >/dev/null 2>&1; then
   download_to() { wget -qO  "$2" "$1"; }
 else
   echo "curl or wget is required." >&2; exit 1
-fi
-
-# Prefer Node.js >= 18 (much smaller download, ~200KB vs ~57MB)
-USE_NODE=0
-if command -v node >/dev/null 2>&1; then
-  NODE_MAJOR=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
-  if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -ge 18 ] 2>/dev/null; then
-    USE_NODE=1
-  fi
-fi
-
-if [ "$USE_NODE" = "0" ]; then
-  # Detect OS
-  case "$(uname -s)" in
-    Darwin) OS="darwin" ;;
-    Linux)  OS="linux"  ;;
-    *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
-  esac
-
-  # Detect architecture
-  case "$(uname -m)" in
-    x86_64|amd64)  ARCH="x64"   ;;
-    arm64|aarch64) ARCH="arm64" ;;
-    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-  esac
-
-  # Rosetta 2: x64 shell on ARM Mac → use native arm64 binary
-  if [ "$OS" = "darwin" ] && [ "$ARCH" = "x64" ]; then
-    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
-      ARCH="arm64"
-    fi
-  fi
-
-  # musl detection on Linux
-  PLATFORM="${OS}-${ARCH}"
-  if [ "$OS" = "linux" ]; then
-    if [ -f /lib/libc.musl-x86_64.so.1 ] || \
-       [ -f /lib/libc.musl-aarch64.so.1 ] || \
-       ldd /bin/ls 2>&1 | grep -q musl; then
-      PLATFORM="${OS}-${ARCH}-musl"
-    fi
-  fi
 fi
 
 # Resolve version from channel
@@ -89,34 +56,23 @@ if [ -z "$VERSION" ]; then
   echo "Failed to resolve version." >&2; exit 1
 fi
 
+echo "Installing minimax ${VERSION}..."
+
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
-# Fetch manifest and extract checksum
-MANIFEST=$(download "${BASE_URL}/manifest.json") || {
-  echo "Failed to fetch manifest.json" >&2; exit 1
-}
-
-if [ "$USE_NODE" = "1" ]; then
-  PLATFORM="node"
-  DOWNLOAD_FILE="minimax.mjs"
-  echo "Installing minimax ${VERSION} (Node.js)..."
-else
-  DOWNLOAD_FILE="minimax-${PLATFORM}"
-  echo "Installing minimax ${VERSION} for ${PLATFORM}..."
-fi
-
-CHECKSUM=$(printf '%s' "$MANIFEST" | tr -d '\n' | \
-  sed "s/.*\"${PLATFORM}\"[^}]*\"checksum\" *: *\"\([a-f0-9]*\)\".*/\1/")
+# Fetch checksum from manifest
+CHECKSUM=$(download "${BASE_URL}/manifest.json" \
+  | grep '"checksum"' | sed 's/.*"checksum": *"\([^"]*\)".*/\1/')
 
 if [ -z "$CHECKSUM" ] || [ "${#CHECKSUM}" -ne 64 ]; then
-  echo "Platform '${PLATFORM}' not found in manifest." >&2; exit 1
+  echo "Failed to fetch manifest." >&2; exit 1
 fi
 
-# Download to temp file
+# Download
 TMP=$(mktemp)
 trap 'rm -f "$TMP"' EXIT
 
-download_to "${BASE_URL}/${DOWNLOAD_FILE}" "$TMP" || {
+download_to "${BASE_URL}/minimax.mjs" "$TMP" || {
   echo "Download failed." >&2; exit 1
 }
 

--- a/package.json
+++ b/package.json
@@ -2,24 +2,16 @@
   "name": "minimax-cli",
   "version": "0.3.1",
   "private": true,
-  "description": "CLI for the MiniMax API Platform (Token Plan)",
+  "description": "CLI for the MiniMax AI Platform",
   "type": "module",
-  "bin": {
-    "minimax": "./dist/minimax.mjs"
-  },
-  "files": [
-    "dist/minimax.mjs"
-  ],
   "scripts": {
     "dev": "bun run src/main.ts",
     "build": "bun run build.ts",
-    "build:dev": "bun build src/main.ts --compile --minify --outfile dist/minimax --define \"process.env.CLI_VERSION='$(node -p \"require('./package.json').version\")'\"",
+    "build:dev": "bun build src/main.ts --outfile dist/minimax.mjs --target node --minify --define \"process.env.CLI_VERSION='$(node -p \"require('./package.json').version'\")'\" && printf '#!/usr/bin/env node\\n' | cat - dist/minimax.mjs > dist/tmp && mv dist/tmp dist/minimax.mjs && chmod +x dist/minimax.mjs",
     "lint": "eslint src/ test/",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "test:watch": "bun test --watch",
-    "build:npm": "bun build src/main.ts --outfile dist/minimax.mjs --target node --define \"process.env.CLI_VERSION='$npm_package_version'\" && printf '#!/usr/bin/env node\\n' | cat - dist/minimax.mjs > dist/tmp && mv dist/tmp dist/minimax.mjs && chmod +x dist/minimax.mjs",
-    "prepublishOnly": "bun run build:npm"
+    "test:watch": "bun test --watch"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0"


### PR DESCRIPTION
## Summary

要求 Node.js 18+，只分发 `minimax.mjs`（112KB）。

| | 之前 | 之后 |
|---|---|---|
| 产物 | 7 个平台二进制 + .mjs | 1 个 minimax.mjs |
| 最大单文件 | 110MB (Windows) | **112KB** |
| build.ts | 50 行 | 20 行 |
| install.sh 逻辑 | OS/arch/musl/Rosetta 检测 | 只检查 `node >= 18` |
| release assets | 9 个文件 | 2 个文件 |

## Changed

- `build.ts`: 只构建 `minimax.mjs`，manifest 只含 version + checksum
- `install.sh`: 简化为 node 版本检查 → 下载 → 校验 → 安装
- `release.yml`: 只上传 `minimax.mjs` + `manifest.json`
- `package.json`: 移除 `bin`/`files`/`build:npm`/`prepublishOnly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)