### PR TITLE
fix: correct file extensions and flag names in SKILL.md

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -5,7 +5,7 @@ Use `minimax` to generate text, images, video, speech, music, and perform web se
 ## Prerequisites
 
 ```bash
-# Auth (persisted to ~/.minimax/credentials.yaml)
+# Auth (persisted to ~/.minimax/credentials.json)
 minimax auth login --api-key sk-xxxxx
 
 # Or pass per-call
@@ -140,7 +140,7 @@ minimax video task get --task-id <id> [--output json]
 Download a completed video by task ID.
 
 ```bash
-minimax video download --task-id <id> [--out <path>]
+minimax video download --file-id <id> [--out <path>]
 ```
 
 ---
@@ -312,7 +312,7 @@ minimax video download --task-id "$TASK" --out robot.mp4
 
 ## Configuration Precedence
 
-CLI flags → environment variables → `~/.minimax/config.yaml` → defaults.
+CLI flags → environment variables → `~/.minimax/config.json` → defaults.
 
 ```bash
 # Persistent config


### PR DESCRIPTION
## Summary

三处文档与代码不符的错误：

- `credentials.yaml` → `credentials.json`（路径实际是 `getCredentialsPath()` 返回 `.json`）
- `config.yaml` → `config.json`（同上，`getConfigPath()` 返回 `.json`）
- `video download --task-id` → `--file-id`（代码中该命令只接受 `--file-id`，`--task-id` 根本不存在）

🤖 Generated with [Claude Code](https://claude.com/claude-code)