### PR TITLE
refactor: api key from file only, interactive setup, dedup utilities

### DIFF
--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -23,14 +23,9 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
     return { token: config.fileApiKey, method: 'api-key', source: 'config.json' };
   }
 
-  // 4. Environment variable
-  if (config.envApiKey) {
-    return { token: config.envApiKey, method: 'api-key', source: 'env' };
-  }
-
   throw new CLIError(
     'No credentials found.',
     ExitCode.AUTH,
-    'Log in:              minimax auth login\nSet env var:         export MINIMAX_API_KEY=sk-xxxxx\nPass directly:       --api-key sk-xxxxx',
+    'Log in:        minimax auth login\nPass directly:  --api-key sk-xxxxx',
   );
 }

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -1,0 +1,45 @@
+import type { Config } from '../config/schema';
+import { readConfigFile, writeConfigFile } from '../config/loader';
+import { promptText, promptConfirm } from '../utils/prompt';
+import { isInteractive } from '../utils/env';
+import { maskToken } from '../utils/token';
+import { CLIError } from '../errors/base';
+import { ExitCode } from '../errors/codes';
+
+export async function ensureApiKey(config: Config): Promise<void> {
+  if (config.apiKey || config.fileApiKey) return;
+
+  const envKey = process.env.MINIMAX_API_KEY;
+  let key: string | undefined;
+
+  if (envKey) {
+    if (!isInteractive({ nonInteractive: config.nonInteractive })) {
+      key = envKey;
+    } else {
+      const use = await promptConfirm({
+        message: `Found MINIMAX_API_KEY in environment (${maskToken(envKey)}). Save it to config file?`,
+      });
+      if (use) key = envKey;
+    }
+  }
+
+  if (!key) {
+    if (!isInteractive({ nonInteractive: config.nonInteractive })) {
+      throw new CLIError(
+        'No API key found.',
+        ExitCode.AUTH,
+        'Set env var:    export MINIMAX_API_KEY=sk-xxxxx\nPass directly:  --api-key sk-xxxxx',
+      );
+    }
+    const input = await promptText({ message: 'Enter your MiniMax API key:' });
+    if (!input) throw new CLIError('API key is required.', ExitCode.AUTH);
+    key = input;
+  }
+
+  const data = { ...(readConfigFile() as Record<string, unknown>), api_key: key };
+  await writeConfigFile(data);
+  config.fileApiKey = key;
+
+  const path = config.configPath ?? '~/.minimax/config.json';
+  process.stderr.write(`API key saved to ${path}\n`);
+}

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -9,6 +9,7 @@ import { quotaEndpoint } from '../../client/endpoints';
 import { getConfigPath } from '../../config/paths';
 import { readConfigFile, writeConfigFile } from '../../config/loader';
 import { isInteractive } from '../../utils/env';
+import { maskToken } from '../../utils/token';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { CredentialFile } from '../../auth/types';
@@ -32,7 +33,7 @@ export default defineCommand({
   async run(config: Config, flags: GlobalFlags) {
     const envKey = process.env.MINIMAX_API_KEY;
     if (envKey) {
-      const maskedEnvKey = envKey.length > 8 ? `${envKey.slice(0, 4)}...${envKey.slice(-4)}` : '***';
+      const maskedEnvKey = maskToken(envKey);
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const { confirm } = await import('@clack/prompts');
         const proceed = await confirm({

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -4,6 +4,8 @@ import { loadCredentials } from '../../auth/credentials';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { requestJson } from '../../client/http';
 import { quotaEndpoint } from '../../client/endpoints';
+import { renderQuotaTable } from '../../output/quota-table';
+import { maskToken } from '../../utils/token';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { QuotaResponse } from '../../types/api';
@@ -33,7 +35,7 @@ export default defineCommand({
             if (creds.account) result.account = creds.account;
           }
         } else {
-          result.key = credential.token.slice(0, 6) + '...' + credential.token.slice(-4);
+          result.key = maskToken(credential.token);
         }
         console.log(formatOutput(result, format));
         return;
@@ -45,8 +47,7 @@ export default defineCommand({
       console.log(`  Source: ${credential.source}`);
 
       const token = credential.token;
-      const maskedToken = token.length > 8 ? `${token.slice(0, 4)}...${token.slice(-4)}` : '***';
-      console.log(`  Key:    ${maskedToken}`);
+      console.log(`  Key:    ${maskToken(token)}`);
 
       if (credential.method === 'oauth') {
         const creds = await loadCredentials();
@@ -59,32 +60,14 @@ export default defineCommand({
       }
 
       // Fetch quota snapshot
-      console.log('');
       process.stderr.write('Fetching quota snapshot...\n');
       try {
         const url = quotaEndpoint(config.baseUrl);
         const quota = await requestJson<QuotaResponse>(config, { url, method: 'GET' });
-        const models = quota.model_remains || [];
-        if (models.length > 0) {
-          console.log('Available Quotas:');
-          for (const m of models.slice(0, 5)) {
-            const remaining = m.current_interval_total_count - m.current_interval_usage_count;
-            const pct = m.current_interval_total_count > 0
-              ? Math.round((remaining / m.current_interval_total_count) * 100)
-              : 0;
-            console.log(`  ${m.model_name.padEnd(24)} ${String(remaining).padStart(6)} / ${m.current_interval_total_count}  (${pct}%)`);
-          }
-          if (models.length > 5) {
-            console.log(`  ... and ${models.length - 5} more (run 'minimax quota show' for full details)`);
-          }
-        } else {
-          console.log('  No quota data available.');
-        }
+        renderQuotaTable(quota.model_remains || [], config);
       } catch (e) {
         console.log(`  Quota fetch failed: ${(e as Error).message}`);
       }
-      console.log('');
-      console.log("Run 'minimax quota show' for full details.");
 
     } catch {
       const format = detectOutputFormat(config.output);

--- a/src/commands/config/show.ts
+++ b/src/commands/config/show.ts
@@ -2,6 +2,7 @@ import { defineCommand } from '../../command';
 import { readConfigFile as loadConfigFile } from '../../config/loader';
 import { getConfigPath } from '../../config/paths';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import { maskToken } from '../../utils/token';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 
@@ -27,7 +28,7 @@ export default defineCommand({
 
     // Mask API key if present
     if (file.api_key) {
-      result.api_key = file.api_key.slice(0, 6) + '...' + file.api_key.slice(-4);
+      result.api_key = maskToken(file.api_key);
     }
 
     console.log(formatOutput(result, format));

--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -4,10 +4,11 @@ import { ExitCode } from '../../errors/codes';
 import { request, requestJson } from '../../client/http';
 import { musicEndpoint } from '../../client/endpoints';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import { saveAudioOutput } from '../../output/audio';
+import { readTextFromPathOrStdin } from '../../utils/fs';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { MusicRequest, MusicResponse } from '../../types/api';
-import { readFileSync, writeFileSync } from 'fs';
 
 export default defineCommand({
   name: 'music generate',
@@ -33,10 +34,7 @@ export default defineCommand({
     let lyrics = flags.lyrics as string | undefined;
 
     if (flags.lyricsFile) {
-      const path = flags.lyricsFile as string;
-      lyrics = path === '-'
-        ? readFileSync('/dev/stdin', 'utf-8')
-        : readFileSync(path, 'utf-8');
+      lyrics = readTextFromPathOrStdin(flags.lyricsFile as string);
     }
 
     if (!prompt && !lyrics) {
@@ -94,35 +92,7 @@ export default defineCommand({
       body,
     });
 
-    if (!config.quiet) {
-      process.stderr.write('[Model: music-2.5]\n');
-    }
-
-    if (outPath) {
-      const audioBuffer = Buffer.from(response.data.audio!, 'hex');
-      writeFileSync(outPath, audioBuffer);
-
-      if (config.quiet) {
-        console.log(outPath);
-      } else {
-        console.log(formatOutput({
-          saved: outPath,
-          duration_ms: response.extra_info?.audio_length,
-          size_bytes: response.extra_info?.audio_size,
-          sample_rate: response.extra_info?.audio_sample_rate,
-        }, format));
-      }
-    } else {
-      const audioUrl = response.data.audio_url ?? response.data.audio;
-      if (config.quiet) {
-        console.log(audioUrl);
-      } else {
-        console.log(formatOutput({
-          url: audioUrl,
-          duration_ms: response.extra_info?.audio_length,
-          size_bytes: response.extra_info?.audio_size,
-        }, format));
-      }
-    }
+    if (!config.quiet) process.stderr.write('[Model: music-2.5]\n');
+    saveAudioOutput(response, outPath, format, config.quiet);
   },
 });

--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -2,169 +2,14 @@ import { defineCommand } from '../../command';
 import { requestJson } from '../../client/http';
 import { quotaEndpoint } from '../../client/endpoints';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import { renderQuotaTable } from '../../output/quota-table';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-
-interface ModelRemain {
-  model_name: string;
-  start_time: number;
-  end_time: number;
-  remains_time: number;
-  current_interval_total_count: number;
-  current_interval_usage_count: number;
-  current_weekly_total_count: number;
-  current_weekly_usage_count: number;
-  weekly_start_time: number;
-  weekly_end_time: number;
-  weekly_remains_time: number;
-}
+import type { QuotaModelRemain } from '../../types/api';
 
 interface QuotaApiResponse {
-  model_remains: ModelRemain[];
+  model_remains: QuotaModelRemain[];
 }
-
-// ── ANSI color constants (MiniMax brand palette) ──
-
-const R = '\x1b[0m';       // reset
-const B = '\x1b[1m';       // bold
-const D = '\x1b[2m';       // dim
-const MM_BLUE = '\x1b[38;2;43;82;255m';
-const MM_CYAN = '\x1b[38;2;6;184;212m';
-const WHITE = '\x1b[38;2;255;255;255m';
-
-// Foreground colors for text (percentage label)
-const FG_GREEN = '\x1b[38;2;74;222;128m';   // #4ADE80  — remaining > 50%
-const FG_YELLOW = '\x1b[38;2;250;204;21m';  // #FACC15  — remaining 20-50%
-const FG_RED = '\x1b[38;2;248;113;113m';     // #F87171  — remaining < 20%
-
-// Background colors for battery-style bar fill
-const BG_GREEN = '\x1b[48;2;22;163;74m';    // #16A34A
-const BG_YELLOW = '\x1b[48;2;202;138;4m';   // #CA8A04
-const BG_RED = '\x1b[48;2;220;38;38m';       // #DC2626
-const BG_EMPTY = '\x1b[48;2;55;65;81m';     // #374151  — dark grey (consumed track)
-
-// Usage-level colors: low usage = green (good), high usage = red (warning)
-function usageColors(usedPct: number): [string, string] {
-  if (usedPct < 50) return [FG_GREEN, BG_GREEN];
-  if (usedPct <= 80) return [FG_YELLOW, BG_YELLOW];
-  return [FG_RED, BG_RED];
-}
-
-// ── i18n labels (CN vs Global) ──
-
-interface Labels {
-  dashboard: string;
-  week: string;
-  weekly: string;
-  resetsIn: string;
-  noData: string;
-  now: string;
-}
-
-const LABELS_EN: Labels = {
-  dashboard: 'Quota Dashboard',
-  week: 'Week',
-  weekly: 'Weekly',
-  resetsIn: 'Resets in',
-  noData: 'No quota data available.',
-  now: 'now',
-};
-
-const LABELS_CN: Labels = {
-  dashboard: '配额面板',
-  week: '周期',
-  weekly: '每周',
-  resetsIn: '重置于',
-  noData: '暂无配额数据',
-  now: '即将',
-};
-
-function formatDuration(ms: number, nowLabel: string): string {
-  if (ms <= 0) return nowLabel;
-  const hours = Math.floor(ms / 3600000);
-  const minutes = Math.floor((ms % 3600000) / 60000);
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
-}
-
-function formatDate(epochMs: number): string {
-  return new Date(epochMs).toISOString().slice(0, 10);
-}
-
-// ── Terminal display-width helper (CJK chars = 2 columns) ──
-
-function isCJK(code: number): boolean {
-  return (
-    (code >= 0x2E80 && code <= 0x9FFF) ||   // CJK Radicals .. CJK Unified Ideographs
-    (code >= 0xF900 && code <= 0xFAFF) ||   // CJK Compatibility Ideographs
-    (code >= 0xFE30 && code <= 0xFE4F) ||   // CJK Compatibility Forms
-    (code >= 0xFF01 && code <= 0xFF60) ||   // Fullwidth Forms
-    (code >= 0x20000 && code <= 0x2FA1F)    // CJK Unified Ideographs Extension B+
-  );
-}
-
-/** Visible column width of a plain string (ANSI-stripped, CJK = 2 cols) */
-function displayWidth(s: string): number {
-  // eslint-disable-next-line no-control-regex
-  const plain = s.replace(/\x1b\[[0-9;]*m/g, '');
-  let w = 0;
-  for (const ch of plain) {
-    w += isCJK(ch.codePointAt(0)!) ? 2 : 1;
-  }
-  return w;
-}
-
-// ── Progress bar renderer (usage-style) ──
-
-const BAR_WIDTH = 16;
-
-/**
- * Usage bar: shows HOW MUCH quota has been consumed.
- * - Colored filled blocks = used portion
- * - Dark grey = remaining capacity
- * @param usedPct - used percentage (0–100)
- */
-function renderBar(usedPct: number, color: boolean): string {
-  const ratio = Math.max(0, Math.min(100, usedPct)) / 100;
-  const filled = Math.round(BAR_WIDTH * ratio);
-  const empty = BAR_WIDTH - filled;
-  const pctStr = `${usedPct}%`.padStart(4);
-
-  if (!color) {
-    // Plain-text: [████............]  1%
-    return `[${'█'.repeat(filled)}${'.'.repeat(empty)}] ${pctStr}`;
-  }
-
-  const [fg, bg] = usageColors(usedPct);
-  // Filled = consumed portion (colored), Empty = remaining (dark grey)
-  return (
-    `${bg}${' '.repeat(filled)}${R}` +
-    `${BG_EMPTY}${' '.repeat(empty)}${R}` +
-    ` ${fg}${B}${pctStr}${R}`
-  );
-}
-
-// ── Box-drawing helpers ──
-
-function line(w: number, left: string, fill: string, right: string, color: boolean): string {
-  if (!color) return `+${'-'.repeat(w)}+`;
-  return `${D}${left}${fill.repeat(w)}${right}${R}`;
-}
-
-function boxTop(w: number, c: boolean): string { return line(w, '╭', '─', '╮', c); }
-function boxMid(w: number, c: boolean): string { return line(w, '├', '─', '┤', c); }
-function boxBot(w: number, c: boolean): string { return line(w, '╰', '─', '╯', c); }
-
-function boxRow(content: string, innerW: number, visLen: number, color: boolean): string {
-  const pad = Math.max(0, innerW - 2 - visLen);
-  return color
-    ? `${D}│${R} ${content}${' '.repeat(pad)} ${D}│${R}`
-    : `| ${content}${' '.repeat(pad)} |`;
-}
-
-// visLen removed — use displayWidth() instead for CJK-safe column counting
-
-// ── Command definition ──
 
 export default defineCommand({
   name: 'quota show',
@@ -183,17 +28,13 @@ export default defineCommand({
     const url = quotaEndpoint(config.baseUrl);
     const response = await requestJson<QuotaApiResponse>(config, { url });
     const models = response.model_remains || [];
-    // Only honour explicit --output flag; ignore config-file output setting so the
-    // rich HUD is shown by default in TTY even when the user has output: json globally.
     const format = detectOutputFormat(flags.output as string | undefined);
 
-    // Step 1: Non-text formats pass through as-is
     if (format !== 'text') {
       console.log(formatOutput(response, format));
       return;
     }
 
-    // Step 2: Quiet mode — machine-parseable TSV
     if (config.quiet) {
       for (const m of models) {
         const remaining = m.current_interval_total_count - m.current_interval_usage_count;
@@ -202,104 +43,6 @@ export default defineCommand({
       return;
     }
 
-    // Step 3: Rich HUD — locale + color detection
-    const useColor = !config.noColor && process.stdout.isTTY === true;
-    const L = config.region === 'cn' ? LABELS_CN : LABELS_EN;
-
-    // Dynamic box width: adapt to longest model name
-    const maxNameLen = models.length > 0
-      ? Math.max(...models.map(m => m.model_name.length))
-      : 16;
-    // color bar:    BAR_WIDTH spaces + ' ' + pct(4)        = BAR_WIDTH + 5 visible cols
-    // no-color bar: '[' + BAR_WIDTH chars + '] ' + pct(4)  = BAR_WIDTH + 7 visible cols
-    const barVisLen = useColor ? BAR_WIDTH + 5 : BAR_WIDTH + 7;
-    // line1 content = name(maxNameLen) + '  '(2) + usage(15) + '  '(2) + bar(barVisLen)
-    // W must be content + 2 so boxRow borders ('| ' + ' |') have room
-    const W = Math.max(68, maxNameLen + 2 + 15 + 2 + barVisLen + 2);
-
-    // ── Header row ──
-    const weekRange = models.length > 0
-      ? `${formatDate(models[0]!.weekly_start_time)} — ${formatDate(models[0]!.weekly_end_time)}`
-      : '';
-
-    const titlePlain = `MINIMAX  ${L.dashboard}`;
-    const weekPlain = `${L.week}: ${weekRange}`;
-    // Use displayWidth for CJK-safe column counting
-    const titleDW = displayWidth(titlePlain);
-    const weekDW = displayWidth(weekPlain);
-    const headerGap = Math.max(2, W - 2 - titleDW - weekDW);
-
-    const titleStyled = useColor
-      ? `${B}${MM_BLUE}MINIMAX${R}  ${D}${L.dashboard}${R}`
-      : titlePlain;
-    const weekStyled = useColor
-      ? `${D}${L.week}:${R} ${MM_CYAN}${weekRange}${R}`
-      : weekPlain;
-
-    const headerContent = `${titleStyled}${' '.repeat(headerGap)}${weekStyled}`;
-    const headerVisLen = titleDW + headerGap + weekDW;
-
-    console.log('');
-    console.log(boxTop(W, useColor));
-    console.log(boxRow(headerContent, W, headerVisLen, useColor));
-
-    if (models.length === 0) {
-      console.log(boxBot(W, useColor));
-      console.log(`\n  ${L.noData}\n`);
-      return;
-    }
-
-    // ── Model rows (each wrapped inside the same box) ──
-    for (let i = 0; i < models.length; i++) {
-      const m = models[i]!;
-      console.log(boxMid(W, useColor));
-
-      // API field "usage_count" is actually the REMAINING count
-      const remaining = m.current_interval_usage_count;
-      const limit = m.current_interval_total_count;
-      const used = Math.max(0, limit - remaining);
-      const usedPct = limit > 0 ? Math.round((used / limit) * 100) : 0;
-      const weekRemaining = m.current_weekly_usage_count;
-      const weekLimit = m.current_weekly_total_count;
-      const weekUsed = Math.max(0, weekLimit - weekRemaining);
-      const resets = formatDuration(m.remains_time, L.now);
-
-      // Line 1: Model name + used/limit fraction + battery bar + remaining %
-      const nameStr = m.model_name.padEnd(maxNameLen);
-      const usageFrac = `${used.toLocaleString()} / ${limit.toLocaleString()}`;
-      const bar = renderBar(usedPct, useColor);
-
-      // color bar:    BAR_WIDTH spaces + gap(1) + pct(4)       = BAR_WIDTH + 5
-      // no-color bar: '[' + BAR_WIDTH chars + '] ' + pct(4)   = BAR_WIDTH + 7
-      const line1VisLen = maxNameLen + 2 + 15 + 2 + barVisLen;
-
-      let line1Styled: string;
-      if (useColor) {
-        const [fg] = usageColors(usedPct);
-        line1Styled = `${B}${WHITE}${nameStr}${R}  ${fg}${usageFrac.padStart(15)}${R}  ${bar}`;
-      } else {
-        line1Styled = `${nameStr}  ${usageFrac.padStart(15)}  ${renderBar(usedPct, false)}`;
-      }
-      console.log(boxRow(line1Styled, W, line1VisLen, useColor));
-
-      // Line 2: Weekly stats (left) + reset timer (right-aligned)
-      const weekFrac = `${weekUsed.toLocaleString()} / ${weekLimit.toLocaleString()}`;
-      const subLeft = `└ ${L.weekly} ${weekFrac}`;
-      const subRight = `${L.resetsIn} ${resets}`;
-      const subLeftDW = displayWidth(subLeft);
-      const subRightDW = displayWidth(subRight);
-      // Inner width = W - 2 (box borders), minus 2 leading spaces, minus left & right content
-      const subGap = Math.max(2, (W - 2) - 2 - subLeftDW - subRightDW);
-      const subPlain = `  ${subLeft}${' '.repeat(subGap)}${subRight}`;
-      const subVisLen = 2 + subLeftDW + subGap + subRightDW;
-
-      const subStyled = useColor
-        ? `  ${D}${subLeft}${' '.repeat(subGap)}${subRight}${R}`
-        : subPlain;
-      console.log(boxRow(subStyled, W, subVisLen, useColor));
-    }
-
-    console.log(boxBot(W, useColor));
-    console.log('');
+    renderQuotaTable(models, config);
   },
 });

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -3,11 +3,12 @@ import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
 import { request, requestJson } from '../../client/http';
 import { speechEndpoint } from '../../client/endpoints';
-import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import { detectOutputFormat, formatOutput } from '../../output/formatter';
+import { saveAudioOutput } from '../../output/audio';
+import { readTextFromPathOrStdin } from '../../utils/fs';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { SpeechRequest, SpeechResponse } from '../../types/api';
-import { readFileSync, writeFileSync } from 'fs';
 
 export default defineCommand({
   name: 'speech synthesize',
@@ -42,10 +43,7 @@ export default defineCommand({
     let text = (flags.text ?? (flags._positional as string[]|undefined)?.[0]) as string | undefined;
 
     if (flags.textFile) {
-      const path = flags.textFile as string;
-      text = path === '-'
-        ? readFileSync('/dev/stdin', 'utf-8')
-        : readFileSync(path, 'utf-8');
+      text = readTextFromPathOrStdin(flags.textFile as string);
     }
 
     if (!text) {
@@ -117,37 +115,7 @@ export default defineCommand({
       body,
     });
 
-    if (!config.quiet) {
-      process.stderr.write(`[Model: ${model}]\n`);
-    }
-
-    if (outPath) {
-      // output_format='hex': data.audio is hex-encoded binary
-      const audioBuffer = Buffer.from(response.data.audio!, 'hex');
-      writeFileSync(outPath, audioBuffer);
-
-      if (config.quiet) {
-        console.log(outPath);
-      } else {
-        console.log(formatOutput({
-          saved: outPath,
-          duration_ms: response.extra_info?.audio_length,
-          size_bytes: response.extra_info?.audio_size,
-          sample_rate: response.extra_info?.audio_sample_rate,
-        }, format));
-      }
-    } else {
-      // output_format='url': API returns URL in data.audio (not data.audio_url)
-      const audioUrl = response.data.audio_url ?? response.data.audio;
-      if (config.quiet) {
-        console.log(audioUrl);
-      } else {
-        console.log(formatOutput({
-          url: audioUrl,
-          duration_ms: response.extra_info?.audio_length,
-          size_bytes: response.extra_info?.audio_size,
-        }, format));
-      }
-    }
+    if (!config.quiet) process.stderr.write(`[Model: ${model}]\n`);
+    saveAudioOutput(response, outPath, format, config.quiet);
   },
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -23,14 +23,13 @@ export function loadConfig(flags: GlobalFlags): Config {
   const file = readConfigFile();
 
   const apiKey = flags.apiKey || undefined;
-  const envApiKey = process.env.MINIMAX_API_KEY || undefined;
   const fileApiKey = file.api_key;
 
   const explicitRegion = (flags.region as string) || process.env.MINIMAX_REGION || undefined;
   const cachedRegion = file.region;
   const region = (explicitRegion || cachedRegion || 'global') as Region;
 
-  const activeKey = apiKey || fileApiKey || envApiKey;
+  const activeKey = apiKey || fileApiKey;
   const needsRegionDetection = !explicitRegion
     && (!cachedRegion || (activeKey !== undefined && activeKey !== file.api_key));
 
@@ -51,8 +50,9 @@ export function loadConfig(flags: GlobalFlags): Config {
 
   return {
     apiKey,
-    envApiKey,
     fileApiKey,
+    fileRegion: file.region,
+    configPath: getConfigPath(),
     region,
     baseUrl,
     output,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,8 +32,9 @@ export function parseConfigFile(raw: unknown): ConfigFile {
 
 export interface Config {
   apiKey?: string;
-  envApiKey?: string;
   fileApiKey?: string;
+  fileRegion?: Region;
+  configPath?: string;
   region: Region;
   baseUrl: string;
   output: 'text' | 'json';

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,19 @@ import { detectRegion, saveDetectedRegion } from './config/detect-region';
 import { REGIONS } from './config/schema';
 import { checkForUpdate, getPendingUpdateNotification } from './update/checker';
 import { loadCredentials } from './auth/credentials';
+import { ensureApiKey } from './auth/setup';
 
 const CLI_VERSION = process.env.CLI_VERSION ?? '0.3.1';
+
+// Commands that manage their own auth or need no key
+const NO_AUTH_SETUP = [
+  ['auth', 'login'],
+  ['auth', 'logout'],
+  ['config', 'show'],
+  ['config', 'set'],
+  ['config', 'export-schema'],
+  ['update'],
+];
 
 async function main() {
   const argv = process.argv.slice(2);
@@ -33,7 +44,7 @@ async function main() {
     const flags = parseFlags(argv, [...GLOBAL_OPTIONS, ...(quotaCmd.options ?? [])]);
     const config = loadConfig(flags);
 
-    const hasKey = !!(config.apiKey || config.envApiKey || config.fileApiKey);
+    const hasKey = !!(config.apiKey || config.fileApiKey);
     const hasOAuth = !!(await loadCredentials());
 
     if (hasKey || hasOAuth) {
@@ -52,8 +63,15 @@ async function main() {
 
   const config = loadConfig(flags);
 
+  const needsAuthSetup = !NO_AUTH_SETUP.some(
+    (cmd) => cmd.every((c, i) => commandPath[i] === c),
+  );
+  if (needsAuthSetup) {
+    await ensureApiKey(config);
+  }
+
   if (config.needsRegionDetection) {
-    const apiKey = config.apiKey || config.fileApiKey || config.envApiKey;
+    const apiKey = config.apiKey || config.fileApiKey;
     if (apiKey) {
       const detected = await detectRegion(apiKey);
       config.region = detected;

--- a/src/output/audio.ts
+++ b/src/output/audio.ts
@@ -1,0 +1,46 @@
+import { writeFileSync } from 'fs';
+import type { OutputFormat } from './formatter';
+import { formatOutput } from './formatter';
+
+interface AudioExtraInfo {
+  audio_length?: number;
+  audio_size?: number;
+  audio_sample_rate?: number;
+}
+
+interface AudioResponse {
+  data: { audio?: string; audio_url?: string };
+  extra_info?: AudioExtraInfo;
+}
+
+export function saveAudioOutput(
+  response: AudioResponse,
+  outPath: string | undefined,
+  format: OutputFormat,
+  quiet: boolean,
+): void {
+  if (outPath) {
+    writeFileSync(outPath, Buffer.from(response.data.audio!, 'hex'));
+    if (quiet) {
+      console.log(outPath);
+    } else {
+      console.log(formatOutput({
+        saved: outPath,
+        duration_ms: response.extra_info?.audio_length,
+        size_bytes: response.extra_info?.audio_size,
+        sample_rate: response.extra_info?.audio_sample_rate,
+      }, format));
+    }
+  } else {
+    const audioUrl = response.data.audio_url ?? response.data.audio;
+    if (quiet) {
+      console.log(audioUrl);
+    } else {
+      console.log(formatOutput({
+        url: audioUrl,
+        duration_ms: response.extra_info?.audio_length,
+        size_bytes: response.extra_info?.audio_size,
+      }, format));
+    }
+  }
+}

--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -1,0 +1,148 @@
+import type { Config } from '../config/schema';
+import type { QuotaModelRemain } from '../types/api';
+
+// ── ANSI color constants ──
+
+const R = '\x1b[0m';
+const B = '\x1b[1m';
+const D = '\x1b[2m';
+const MM_BLUE = '\x1b[38;2;43;82;255m';
+const MM_CYAN = '\x1b[38;2;6;184;212m';
+const WHITE = '\x1b[38;2;255;255;255m';
+const FG_GREEN = '\x1b[38;2;74;222;128m';
+const FG_YELLOW = '\x1b[38;2;250;204;21m';
+const FG_RED = '\x1b[38;2;248;113;113m';
+const BG_GREEN = '\x1b[48;2;22;163;74m';
+const BG_YELLOW = '\x1b[48;2;202;138;4m';
+const BG_RED = '\x1b[48;2;220;38;38m';
+const BG_EMPTY = '\x1b[48;2;55;65;81m';
+
+function usageColors(usedPct: number): [string, string] {
+  if (usedPct < 50) return [FG_GREEN, BG_GREEN];
+  if (usedPct <= 80) return [FG_YELLOW, BG_YELLOW];
+  return [FG_RED, BG_RED];
+}
+
+interface Labels {
+  dashboard: string;
+  week: string;
+  weekly: string;
+  resetsIn: string;
+  noData: string;
+  now: string;
+}
+
+const LABELS_EN: Labels = { dashboard: 'Quota Dashboard', week: 'Week', weekly: 'Weekly', resetsIn: 'Resets in', noData: 'No quota data available.', now: 'now' };
+const LABELS_CN: Labels = { dashboard: '配额面板', week: '周期', weekly: '每周', resetsIn: '重置于', noData: '暂无配额数据', now: '即将' };
+
+function formatDuration(ms: number, nowLabel: string): string {
+  if (ms <= 0) return nowLabel;
+  const hours = Math.floor(ms / 3600000);
+  const minutes = Math.floor((ms % 3600000) / 60000);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+function formatDate(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+function isCJK(code: number): boolean {
+  return (code >= 0x2E80 && code <= 0x9FFF) || (code >= 0xF900 && code <= 0xFAFF) ||
+    (code >= 0xFE30 && code <= 0xFE4F) || (code >= 0xFF01 && code <= 0xFF60) ||
+    (code >= 0x20000 && code <= 0x2FA1F);
+}
+
+function displayWidth(s: string): number {
+  // eslint-disable-next-line no-control-regex
+  const plain = s.replace(/\x1b\[[0-9;]*m/g, '');
+  let w = 0;
+  for (const ch of plain) w += isCJK(ch.codePointAt(0)!) ? 2 : 1;
+  return w;
+}
+
+const BAR_WIDTH = 16;
+
+function renderBar(usedPct: number, color: boolean): string {
+  const ratio = Math.max(0, Math.min(100, usedPct)) / 100;
+  const filled = Math.round(BAR_WIDTH * ratio);
+  const empty = BAR_WIDTH - filled;
+  const pctStr = `${usedPct}%`.padStart(4);
+  if (!color) return `[${'█'.repeat(filled)}${'.'.repeat(empty)}] ${pctStr}`;
+  const [fg, bg] = usageColors(usedPct);
+  return `${bg}${' '.repeat(filled)}${R}${BG_EMPTY}${' '.repeat(empty)}${R} ${fg}${B}${pctStr}${R}`;
+}
+
+function boxLine(w: number, l: string, f: string, r: string, c: boolean): string {
+  return c ? `${D}${l}${f.repeat(w)}${r}${R}` : `+${'-'.repeat(w)}+`;
+}
+
+function boxRow(content: string, innerW: number, visLen: number, color: boolean): string {
+  const pad = Math.max(0, innerW - 2 - visLen);
+  return color ? `${D}│${R} ${content}${' '.repeat(pad)} ${D}│${R}` : `| ${content}${' '.repeat(pad)} |`;
+}
+
+export function renderQuotaTable(models: QuotaModelRemain[], config: Config): void {
+  const useColor = !config.noColor && process.stdout.isTTY === true;
+  const L = config.region === 'cn' ? LABELS_CN : LABELS_EN;
+
+  const maxNameLen = models.length > 0 ? Math.max(...models.map(m => m.model_name.length)) : 16;
+  const barVisLen = useColor ? BAR_WIDTH + 5 : BAR_WIDTH + 7;
+  const W = Math.max(68, maxNameLen + 2 + 15 + 2 + barVisLen + 2);
+
+  const weekRange = models.length > 0
+    ? `${formatDate(models[0]!.weekly_start_time)} — ${formatDate(models[0]!.weekly_end_time)}`
+    : '';
+
+  const titlePlain = `MINIMAX  ${L.dashboard}`;
+  const weekPlain = `${L.week}: ${weekRange}`;
+  const headerGap = Math.max(2, W - 2 - displayWidth(titlePlain) - displayWidth(weekPlain));
+  const headerContent = useColor
+    ? `${B}${MM_BLUE}MINIMAX${R}  ${D}${L.dashboard}${R}${' '.repeat(headerGap)}${D}${L.week}:${R} ${MM_CYAN}${weekRange}${R}`
+    : `${titlePlain}${' '.repeat(headerGap)}${weekPlain}`;
+  const headerVisLen = displayWidth(titlePlain) + headerGap + displayWidth(weekPlain);
+
+  console.log('');
+  console.log(boxLine(W, '╭', '─', '╮', useColor));
+  console.log(boxRow(headerContent, W, headerVisLen, useColor));
+
+  if (models.length === 0) {
+    console.log(boxLine(W, '╰', '─', '╯', useColor));
+    console.log(`\n  ${L.noData}\n`);
+    return;
+  }
+
+  for (const m of models) {
+    console.log(boxLine(W, '├', '─', '┤', useColor));
+
+    const remaining = m.current_interval_usage_count;
+    const limit = m.current_interval_total_count;
+    const used = Math.max(0, limit - remaining);
+    const usedPct = limit > 0 ? Math.round((used / limit) * 100) : 0;
+    const weekRemaining = m.current_weekly_usage_count;
+    const weekLimit = m.current_weekly_total_count;
+    const weekUsed = Math.max(0, weekLimit - weekRemaining);
+    const resets = formatDuration(m.remains_time, L.now);
+
+    const nameStr = m.model_name.padEnd(maxNameLen);
+    const usageFrac = `${used.toLocaleString()} / ${limit.toLocaleString()}`;
+    const bar = renderBar(usedPct, useColor);
+    const line1VisLen = maxNameLen + 2 + 15 + 2 + barVisLen;
+
+    const line1 = useColor
+      ? `${B}${WHITE}${nameStr}${R}  ${usageColors(usedPct)[0]}${usageFrac.padStart(15)}${R}  ${bar}`
+      : `${nameStr}  ${usageFrac.padStart(15)}  ${renderBar(usedPct, false)}`;
+    console.log(boxRow(line1, W, line1VisLen, useColor));
+
+    const subLeft = `└ ${L.weekly} ${weekUsed.toLocaleString()} / ${weekLimit.toLocaleString()}`;
+    const subRight = `${L.resetsIn} ${resets}`;
+    const subGap = Math.max(2, (W - 2) - 2 - displayWidth(subLeft) - displayWidth(subRight));
+    const subVisLen = 2 + displayWidth(subLeft) + subGap + displayWidth(subRight);
+    const sub = useColor
+      ? `  ${D}${subLeft}${' '.repeat(subGap)}${subRight}${R}`
+      : `  ${subLeft}${' '.repeat(subGap)}${subRight}`;
+    console.log(boxRow(sub, W, subVisLen, useColor));
+  }
+
+  console.log(boxLine(W, '╰', '─', '╯', useColor));
+  console.log('');
+}

--- a/src/output/status-bar.ts
+++ b/src/output/status-bar.ts
@@ -1,4 +1,6 @@
 import type { Config } from '../config/schema';
+import { homedir } from 'os';
+import { maskToken } from '../utils/token';
 
 let printed = false;
 
@@ -10,19 +12,27 @@ const mmPurple = '\x1b[38;2;147;51;234m';
 const mmCyan   = '\x1b[38;2;6;184;212m';
 const mmPink   = '\x1b[38;2;236;72;153m';
 
+function tildePath(p: string): string {
+  return p.startsWith(homedir()) ? p.replace(homedir(), '~') : p;
+}
+
 export function maybeShowStatusBar(config: Config, token: string, model?: string): void {
   if (config.quiet || printed || !process.stderr.isTTY) return;
   printed = true;
 
-  const region    = config.baseUrl.includes('minimaxi.com') ? 'CN' : 'Global';
-  const maskedKey = token.length > 8 ? `${token.slice(0, 4)}...${token.slice(-4)}` : '***';
-  const modelStr  = model ? ` ${dim}|${reset} ${dim}Model:${reset} ${mmPurple}${model}${reset}` : '';
+  const filePath   = config.configPath ? tildePath(config.configPath) : '~/.minimax/config.json';
+  const regionSrc  = config.fileRegion ? `${config.fileRegion} (file)` : 'global (default)';
+  const keySrc     = config.apiKey ? '(flag)' : '(file)';
+  const maskedKey  = maskToken(token);
+  const modelStr   = model ? ` ${dim}|${reset} ${dim}Model:${reset} ${mmPurple}${model}${reset}` : '';
 
   process.stderr.write(
     `${bold}${mmBlue}MINIMAX${reset} ` +
-    `${dim}Region:${reset} ${mmCyan}${region}${reset} ` +
+    `${dim}${filePath}${reset} ` +
     `${dim}|${reset} ` +
-    `${dim}Key:${reset} ${mmPink}${maskedKey}${reset}` +
+    `${dim}Region:${reset} ${mmCyan}${regionSrc}${reset} ` +
+    `${dim}|${reset} ` +
+    `${dim}Key:${reset} ${mmPink}${maskedKey}${reset} ${dim}${keySrc}${reset}` +
     `${modelStr}\n`,
   );
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from 'fs';
+
+export function readTextFromPathOrStdin(path: string): string {
+  return readFileSync(path === '-' ? '/dev/stdin' : path, 'utf-8');
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,0 +1,3 @@
+export function maskToken(token: string): string {
+  return token.length > 8 ? `${token.slice(0, 4)}...${token.slice(-4)}` : '***';
+}

--- a/test/auth/resolver.test.ts
+++ b/test/auth/resolver.test.ts
@@ -20,14 +20,8 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 }
 
 describe('resolveCredential', () => {
-  const originalEnv = process.env.MINIMAX_API_KEY;
-
   afterEach(() => {
-    if (originalEnv) {
-      process.env.MINIMAX_API_KEY = originalEnv;
-    } else {
-      delete process.env.MINIMAX_API_KEY;
-    }
+    delete process.env.MINIMAX_API_KEY;
   });
 
   it('resolves from flag (apiKey in config)', async () => {
@@ -35,13 +29,6 @@ describe('resolveCredential', () => {
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-from-flag');
     expect(cred.method).toBe('api-key');
-  });
-
-  it('resolves from env var', async () => {
-    const config = makeConfig({ envApiKey: 'sk-from-env' });
-    const cred = await resolveCredential(config);
-    expect(cred.token).toBe('sk-from-env');
-    expect(cred.source).toBe('env');
   });
 
   it('resolves from config file api key', async () => {
@@ -59,19 +46,6 @@ describe('resolveCredential', () => {
 
   it('prefers flag over file api key', async () => {
     const config = makeConfig({ apiKey: 'sk-flag', fileApiKey: 'sk-file' });
-    const cred = await resolveCredential(config);
-    expect(cred.token).toBe('sk-flag');
-  });
-
-  it('prefers config file over env var', async () => {
-    const config = makeConfig({ fileApiKey: 'sk-file', envApiKey: 'sk-env' });
-    const cred = await resolveCredential(config);
-    expect(cred.token).toBe('sk-file');
-    expect(cred.source).toBe('config.json');
-  });
-
-  it('env var is lowest priority', async () => {
-    const config = makeConfig({ apiKey: 'sk-flag', fileApiKey: 'sk-file', envApiKey: 'sk-env' });
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-flag');
   });


### PR DESCRIPTION
## Summary

**Auth 重构**
- `resolver.ts` 移除 env fallback，file 是唯一持久化来源
- 新增 `ensureApiKey()` 交互式引导：file → 询问是否用 ENV → 手动输入
- status bar 展示 config 文件路径及 key/region 来源

**重复逻辑消除**
- `renderQuotaTable()` — `quota show` 和 `auth status` 共用同一富文本表格
- `saveAudioOutput()` — `speech synthesize` 和 `music generate` 共用 audio 输出逻辑
- `readTextFromPathOrStdin()` — speech/music 共用 stdin 读取
- `maskToken()` — 替换 5 处各有差异的手写 slice

## Test plan

- [x] `bun test` — 58/58 pass
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)