### PR TITLE
fix: migrate quota endpoints from www to api subdomain

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -39,8 +39,8 @@ export function vlmEndpoint(baseUrl: string): string {
 }
 
 export function quotaEndpoint(baseUrl: string): string {
-  // Quota endpoint uses www subdomain, not api subdomain
-  const host = baseUrl.includes('minimaxi.com') ? 'https://www.minimaxi.com' : 'https://www.minimax.io';
+  // Quota endpoint uses api subdomain
+  const host = baseUrl.includes('minimaxi.com') ? 'https://api.minimaxi.com' : 'https://api.minimax.io';
   return `${host}/v1/api/openplatform/coding_plan/remains`;
 }
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -32,7 +32,7 @@ export default defineCommand({
   ],
   async run(config: Config, flags: GlobalFlags) {
     const envKey = process.env.MINIMAX_API_KEY;
-    if (envKey) {
+    if (envKey && !flags.apiKey) {
       const maskedEnvKey = maskToken(envKey);
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const { confirm } = await import('@clack/prompts');

--- a/src/config/detect-region.ts
+++ b/src/config/detect-region.ts
@@ -4,7 +4,7 @@ import { readConfigFile, writeConfigFile } from './loader';
 const QUOTA_PATH = '/v1/api/openplatform/coding_plan/remains';
 
 function quotaUrl(region: Region): string {
-  return REGIONS[region].replace('://api.', '://www.') + QUOTA_PATH;
+  return REGIONS[region] + QUOTA_PATH;
 }
 
 async function probeRegion(region: Region, apiKey: string, timeoutMs: number): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Quota API 域名从 `www.minimaxi.com` / `www.minimax.io` 迁移到 `api.minimaxi.com` / `api.minimax.io`
- 修复 region 探测时仍使用旧 `www.` 域名导致检测失败的问题
- 显式传 `--api-key` 时跳过环境变量提示，直接验证保存

## Test plan
- [ ] `minimax auth login --api-key <key>` region 探测成功且保存到 config.json
- [ ] 设置 `MINIMAX_API_KEY` 环境变量后，`minimax auth login --api-key <key>` 不再弹出环境变量提示
- [ ] `minimax quota show` 正常返回余量数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)