### PR TITLE
fix: Node.js compatibility for file upload and status bar

### DIFF
--- a/src/commands/file/upload.ts
+++ b/src/commands/file/upload.ts
@@ -10,7 +10,8 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { FileUploadResponse } from '../../types/api';
 import { existsSync } from 'fs';
-import { resolve } from 'path';
+import { readFile } from 'fs/promises';
+import { resolve, basename } from 'path';
 
 export default defineCommand({
   name: 'file upload',
@@ -53,9 +54,9 @@ export default defineCommand({
     }
 
     const formData = new FormData();
-    // Read file as a Blob-like File object for fetch compatibility
-    const fileData = await Bun.file(fullPath).arrayBuffer();
-    const fileName = fullPath.split('/').pop() || 'file';
+    // Read file using Node.js fs/promises (compatible with both Node and Bun)
+    const fileData = await readFile(fullPath);
+    const fileName = basename(fullPath);
     const fileBlob = new Blob([fileData]);
     formData.append('file', fileBlob, fileName);
     formData.append('purpose', purpose);

--- a/src/output/status-bar.ts
+++ b/src/output/status-bar.ts
@@ -4,6 +4,10 @@ import { maskToken } from '../utils/token';
 
 let printed = false;
 
+export function resetStatusBar(): void {
+  printed = false;
+}
+
 const reset    = '\x1b[0m';
 const dim      = '\x1b[2m';
 const bold     = '\x1b[1m';


### PR DESCRIPTION
## Summary

Two fixes for Node.js compatibility:

### 1. `file/upload.ts` — Replace Bun-specific APIs

- `Bun.file(path).arrayBuffer()` → `fs/promises.readFile()`
- `path.split("/").pop()` → `path.basename()`

This allows the CLI to run in pure Node.js 18+ environments without Bun.

### 2. `status-bar.ts` — Export `resetStatusBar()`

The module-level `printed` state variable caused test pollution between runs (Issue #9).


Exporting `resetStatusBar()` lets tests reset state cleanly between test cases.