### PR TITLE
fix(config): use atomic write (tmp+rename) for credentials and config files

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, unlinkSync, existsSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync, statSync } from 'fs';
 import { getCredentialsPath, ensureConfigDir } from '../config/paths';
 import type { CredentialFile } from './types';
 
@@ -20,7 +20,9 @@ export async function loadCredentials(): Promise<CredentialFile | null> {
 export async function saveCredentials(creds: CredentialFile): Promise<void> {
   await ensureConfigDir();
   const path = getCredentialsPath();
-  writeFileSync(path, JSON.stringify(creds, null, 2) + '\n', { mode: 0o600 });
+  const tmp = path + '.tmp';
+  writeFileSync(tmp, JSON.stringify(creds, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, path);
 }
 
 export async function clearCredentials(): Promise<void> {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, renameSync, existsSync } from 'fs';
 import { parseConfigFile, REGIONS, type Config, type ConfigFile, type Region } from './schema';
 import { ensureConfigDir, getConfigPath } from './paths';
 import { detectOutputFormat, type OutputFormat } from '../output/formatter';
@@ -16,7 +16,10 @@ export function readConfigFile(): ConfigFile {
 
 export async function writeConfigFile(data: Record<string, unknown>): Promise<void> {
   await ensureConfigDir();
-  writeFileSync(getConfigPath(), JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+  const path = getConfigPath();
+  const tmp = path + '.tmp';
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, path);
 }
 
 export function loadConfig(flags: GlobalFlags): Config {


### PR DESCRIPTION
## Summary

Write credentials and config files to a `.tmp` file first, then atomically rename to the target path. This prevents file corruption if the process is killed mid-write or in case of an unexpected interruption during the write operation.

## Changes

- `src/auth/credentials.ts`: `saveCredentials()` now uses `tmp + renameSync` pattern
- `src/config/loader.ts`: `writeConfigFile()` now uses `tmp + renameSync` pattern

## Test plan

- [ ] Simulate process kill during `minimax auth login` and verify config files remain intact
- [ ] Run multiple concurrent `minimax` instances and verify no credential file corruption