### PR TITLE
feat(skill): add skill-lite (lightweight version for agent use)

### DIFF
--- a/skill-lite/README.md
+++ b/skill-lite/README.md
@@ -1,0 +1,65 @@
+# skill-lite
+
+轻量版 MiniMax CLI skill，适合 token 敏感的 agent 环境。
+
+## 设计理念：复用 CLI 原生渐进式披露
+
+**MiniMax CLI 的核心设计是渐进式披露（Progressive Disclosure）：**
+
+```
+minimax --help           # 第一层：所有资源
+minimax music --help     # 第二层：该资源下的所有动词
+minimax music generate --help  # 第三层：该命令的完整参数表
+```
+
+用户从顶层逐步深入，按需获取信息，不需要记忆复杂文档。
+
+**skill-lite 的设计复用这个理念：**
+
+- 不在 skill 里复制完整参数表（那样会重复 CLI 的功能，且需同步维护）
+- 只列高频命令，引导 agent 用 `--help` 获取完整参数
+- references/ 提供关键信息速查（agent flags、exit codes），但不是完整参数表
+
+**为什么这样更合理：**
+
+| 方案 | 问题 |
+|------|------|
+| 在 skill 里复制完整参数表 | 1. 重复 CLI 功能；2. 每次 CLI 更新参数都要同步改 skill；3. token 消耗高 |
+| 引导用 `--help` | 1. 参数始终最新（CLI 自己维护）；2. skill 几乎不需要维护；3. token 消耗低 |
+
+**Token 节省：**
+
+| 版本 | Token 消耗 |
+|------|------------|
+| skill/SKILL.md（全量） | ~4000 |
+| skill-lite/（轻量） | ~1000 |
+
+节省约 75%，对于 token 受限的 agent 框架意义重大。
+
+## 与 skill/SKILL.md 的区别
+
+| 项目 | skill/SKILL.md（全量） | skill-lite/（轻量） |
+|------|------------------------|---------------------|
+| Token 消耗 | ~4000 | ~1000 |
+| 参数表 | 完整列出 | 引导用 `--help` |
+| 分层 | 单层 | 三层（references 按需加载） |
+| 维护成本 | 高（需同步 CLI 更新） | 低（引导而非复制） |
+| 设计理念 | 人类参考文档 | 复用 CLI 渐进式披露 |
+
+## 适用场景
+
+- **skill/SKILL.md**：IDE 集成、人类参考、需要完整离线文档
+- **skill-lite/**：OpenClaw、Claude Code、其他 token 受限的 agent 框架
+
+## 使用方式
+
+将 `skill-lite/` 复制到你的 agent skill 目录，或让 agent 框架加载 `SKILL.md`。
+
+Agent 触发时会：
+1. 只加载 `SKILL.md`（轻量，~60 行）
+2. 需要更多信息时读 `references/`
+3. 需要完整参数时用 `minimax <command> --help`
+
+## 两个版本并存
+
+`skill/SKILL.md` 和 `skill-lite/` 都是官方支持的版本，用户可根据场景选择。

--- a/skill-lite/SKILL.md
+++ b/skill-lite/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: minimax-lite
+description: MiniMax 多模态能力调用（轻量版）。确保使用此 skill 当用户需要生成音乐、语音、图像、视频，或任何涉及 AI 生成内容（配乐、配音、配图、视频素材）时。即使没有明确说"生成"，只要描述了创作需求，也应触发。不要尝试用其他方式，优先使用 CLI。
+---
+
+# MiniMax 多模态能力（轻量版）
+
+这是 `skill/SKILL.md` 的轻量替代版本，适合 token 敏感的 agent 环境。
+
+**与全量版区别：**
+- 只列高频命令，引导用 `--help` 渐进获取参数
+- references/ 按需加载，不预加载全部参数表
+- token 消耗约 1000（全量版约 4000）
+
+**适用场景：** OpenClaw、Claude Code 等 agent 框架。
+
+## 为什么用 CLI？
+
+CLI 优先于直接调用 API：
+
+1. **渐进式披露**：`--help` 系统始终是最新的参数说明，无需维护 skill 里的参数表
+2. **官方维护**：API 变更时 CLI 自动更新，skill 无需同步改动
+3. **错误处理内置**：重试、认证刷新、友好错误提示都已处理好
+4. **统一入口**：所有能力一致的命令结构
+
+## 前置条件
+
+```bash
+npm install -g @minimax/cli
+minimax auth login
+```
+
+## 高频命令
+
+```bash
+minimax text chat --message "<文本>"
+minimax speech synthesize --text "<文本>" --out speech.mp3
+minimax image generate --prompt "<描述>"
+minimax video generate --prompt "<描述>"
+minimax music generate --prompt "<风格>" --instrumental           # 纯音乐
+minimax music generate --prompt "<风格>" --lyrics "<歌词>"         # 带歌词
+```
+
+## 使用原则
+
+1. **先看帮助**：不确定参数时，用 `minimax <command> --help`
+2. **Agent 模式**：加 `--non-interactive --quiet`，必要时 `--output json`
+3. **参数精简**：大部分情况只需要核心参数，其余用 `--help` 按需补充
+
+## 需要更多信息时
+
+| 场景 | 做法 |
+|------|------|
+| 完整参数列表 | `minimax <command> --help`（首选，始终最新）|
+| Agent flags 速查 | 读 [references/agent-flags.md](references/agent-flags.md) |
+| 命令参数速查 | 读 [references/commands.md](references/commands.md) |
+| 错误码含义 | 读 [references/exit-codes.md](references/exit-codes.md) |
+
+## 能力状态
+
+| 能力 | 命令 | 状态 |
+|------|------|------|
+| 文本对话 | `minimax text chat` | ✅ |
+| 图像生成 | `minimax image generate` | ✅ |
+| 视频生成 | `minimax video generate` | ✅ |
+| 语音合成 | `minimax speech synthesize` | ✅ |
+| 音乐生成 | `minimax music generate` | ✅ |
+| 图像理解 | `minimax vision describe` | ✅ |
+| 网页搜索 | `minimax search query` | ✅ |
+| 声音克隆 | - | 🚧 等 CLI 支持 |
+| 声音设计 | - | 🚧 等 CLI 支持 |
+| 视频主体参考 | - | 🚧 S2V-01，等 CLI |
+| 首尾帧插值 | - | 🚧 SEF 模式，等 CLI |

--- a/skill-lite/references/agent-flags.md
+++ b/skill-lite/references/agent-flags.md
@@ -1,0 +1,27 @@
+# Agent Flags
+
+在非交互（agent/CI）环境下始终加这些 flags：
+
+| Flag | 作用 |
+|------|------|
+| `--non-interactive` | 缺少参数时直接报错，不弹出交互提示 |
+| `--quiet` | 关闭 spinner/进度条，stdout 输出纯数据 |
+| `--output json` | 机器可读的 JSON 输出 |
+| `--async` | 立即返回 task ID（视频生成适用） |
+| `--dry-run` | 预览 API 请求，不实际执行 |
+| `--yes` | 跳过确认提示 |
+
+## 典型 agent 调用模板
+
+```bash
+# 图像生成（同步，直接得到 URL）
+minimax image generate --prompt "..." --non-interactive --quiet --output json
+
+# 视频生成（异步，先拿 task ID）
+TASK=$(minimax video generate --prompt "..." --async --non-interactive --quiet | jq -r '.taskId')
+minimax video task get --task-id "$TASK" --output json
+minimax video download --task-id "$TASK" --out video.mp4
+
+# 语音合成（输出到文件）
+minimax speech synthesize --text "..." --out speech.mp3 --non-interactive --quiet
+```

--- a/skill-lite/references/commands.md
+++ b/skill-lite/references/commands.md
@@ -1,0 +1,199 @@
+# 完整命令参考
+
+> 这里是各命令关键参数速查。完整参数列表始终以 `minimax <command> --help` 为准。
+
+---
+
+## text chat
+
+文本对话，默认模型 `MiniMax-M2.7`。
+
+```bash
+minimax text chat --message "<文本>" [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--message <text>` | 消息文本，前缀 `role:` 设置角色，如 `"system:You are helpful"` |
+| `--messages-file <path>` | 从 JSON 文件读取消息，`-` 读 stdin |
+| `--system <text>` | 系统提示 |
+| `--model <model>` | 模型 ID，默认 `MiniMax-M2.7` |
+| `--stream` | 流式输出 |
+
+---
+
+## image generate
+
+图像生成，模型 `image-01`。
+
+```bash
+minimax image generate --prompt <text> [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--prompt` | 图像描述（必填） |
+| `--aspect-ratio` | 比例，如 `16:9`、`1:1` |
+| `--n` | 生成数量，默认 1 |
+| `--subject-ref` | 主体参考：`type=character,image=path-or-url` |
+| `--out-dir` | 下载图片到目录 |
+| `--out-prefix` | 文件名前缀，默认 `image` |
+
+---
+
+## video generate
+
+视频生成，默认模型 `MiniMax-Hailuo-2.3`。异步任务，默认轮询至完成。
+
+```bash
+minimax video generate --prompt <text> [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--prompt` | 视频描述（必填） |
+| `--model` | `MiniMax-Hailuo-2.3`（默认）或 `MiniMax-Hailuo-2.3-Fast` |
+| `--first-frame` | 首帧图片路径或 URL（图生视频） |
+| `--download <path>` | 完成后下载到指定文件 |
+| `--async` | 立即返回 task ID，不等待 |
+| `--poll-interval` | 轮询间隔（秒），默认 5 |
+
+### 配套命令
+
+```bash
+# 查询任务状态
+minimax video task get --task-id <id> [--output json]
+
+# 下载已完成视频
+minimax video download --file-id <id> [--out <path>]
+```
+
+---
+
+## speech synthesize
+
+文字转语音，默认模型 `speech-2.8-hd`，最大 10k 字符。
+
+```bash
+minimax speech synthesize --text <text> [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--text` | 要合成的文本 |
+| `--text-file <path>` | 从文件读取，`-` 读 stdin |
+| `--model` | `speech-2.8-hd`（默认）、`speech-2.6`、`speech-02` |
+| `--voice <id>` | 音色 ID，默认 `English_expressive_narrator` |
+| `--speed` | 语速倍率 |
+| `--pitch` | 音高调整 |
+| `--format` | 格式，默认 `mp3` |
+| `--out <path>` | 保存到文件 |
+| `--stream` | 流式输出原始音频到 stdout |
+
+**查询可用音色：**
+```bash
+minimax speech voices
+```
+
+---
+
+## music generate
+
+音乐生成，模型 `music-2.5`。
+
+```bash
+minimax music generate --prompt "<风格描述>" --lyrics "<歌词>" [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--prompt` | 音乐风格描述（可详细描述） |
+| `--lyrics` | 歌词（含结构标签），用 `无歌词` 表示纯音乐。不能与 `--instrumental` 同时使用 |
+| `--lyrics-file` | 从文件读取歌词，`-` 读 stdin |
+| `--vocals` | 人声风格，如 `"warm male baritone"`、`"bright female soprano"`、`"duet with harmonies"` |
+| `--genre` | 流派，如 folk、pop、jazz |
+| `--mood` | 情绪，如 warm、melancholic、uplifting |
+| `--instruments` | 乐器，如 `"acoustic guitar, piano"` |
+| `--tempo` | 节奏描述，如 fast、slow、moderate |
+| `--bpm` | 精确 BPM（数字） |
+| `--key` | 调式，如 `C major`、`A minor`、`G sharp` |
+| `--avoid` | 要避免的元素 |
+| `--use-case` | 使用场景，如 `"background music for video"`、`"theme song"` |
+| `--structure` | 歌曲结构，如 `"verse-chorus-verse-bridge-chorus"` |
+| `--references` | 参考曲目或艺术家，如 `"similar to Ed Sheeran"` |
+| `--extra` | 其他未覆盖的细节要求 |
+| `--instrumental` | 纯音乐模式（无人声）。不能与 `--lyrics`/`--lyrics-file` 同时使用 |
+| `--aigc-watermark` | 嵌入 AI 内容水印（用于内容溯源） |
+| `--format` | 音频格式，默认 `mp3` |
+| `--sample-rate` | 采样率，默认 44100 |
+| `--bitrate` | 比特率，默认 256000 |
+| `--stream` | 流式输出原始音频到 stdout |
+| `--out <path>` | 保存到文件 |
+
+---
+
+## vision describe
+
+图像理解。
+
+```bash
+minimax vision describe --image <path-or-url> [--prompt "<问题>"] [flags]
+```
+
+| Flag | 说明 |
+|------|------|
+| `--image` | 本地路径或 URL（自动 base64） |
+| `--file-id` | 预上传的文件 ID |
+| `--prompt` | 提问，默认 `"Describe the image."` |
+
+---
+
+## search query
+
+网页搜索。
+
+```bash
+minimax search query --q "<查询>" [--output json]
+```
+
+---
+
+## quota show
+
+查看配额使用情况。
+
+```bash
+minimax quota show [--output json]
+```
+
+---
+
+## config export-schema
+
+导出 Anthropic/OpenAI 兼容的工具 schema，用于 agent 框架注册。
+
+```bash
+# 所有命令
+minimax config export-schema
+
+# 单个命令
+minimax config export-schema --command "video generate"
+```
+
+---
+
+## 管道用法
+
+```bash
+# stdout 始终是纯数据，可安全管道
+minimax text chat --message "Hi" --output json | jq '.content'
+
+# 链式：生成图片 → 描述图片
+URL=$(minimax image generate --prompt "A sunset" --quiet)
+minimax vision describe --image "$URL" --quiet
+
+# 异步视频工作流
+TASK=$(minimax video generate --prompt "A robot" --async --quiet | jq -r '.taskId')
+minimax video task get --task-id "$TASK" --output json
+minimax video download --task-id "$TASK" --out robot.mp4
+```

--- a/skill-lite/references/exit-codes.md
+++ b/skill-lite/references/exit-codes.md
@@ -1,0 +1,26 @@
+# Exit Codes
+
+| Code | 含义 |
+|------|------|
+| 0 | 成功 |
+| 1 | 通用错误 / 服务端错误 |
+| 2 | 用法错误（参数错误、缺少必填项） |
+| 3 | 认证错误 |
+| 4 | 配额超限 |
+| 5 | 超时 |
+| 10 | 内容安全过滤触发 |
+
+## 在 agent 中处理
+
+```bash
+minimax image generate --prompt "..." --quiet
+EXIT=$?
+
+case $EXIT in
+  0) echo "成功" ;;
+  3) minimax auth login ;;   # 重新认证
+  4) echo "配额不足，检查账户" ;;
+  10) echo "内容被过滤，修改 prompt" ;;
+  *) echo "错误: $EXIT" ;;
+esac
+```


### PR DESCRIPTION
## Summary

Add `skill-lite/` as a lightweight alternative to `skill/SKILL.md`.

**Designed for token-sensitive agent environments** like OpenClaw and Claude Code.

## Key Differences

| Item | skill/SKILL.md (Full) | skill-lite/ (Lite) |
|------|------------------------|-------------------|
| Token cost | ~4000 | ~1000 |
| Parameter tables | Full list | Guide to --help |
| Layering | Single layer | Three layers (references on-demand) |
| Maintenance | High (sync with CLI updates) | Low (guide rather than copy) |

## Structure

skill-lite/
- SKILL.md (Entry point, ~60 lines)
- README.md (Usage guide)
- references/
  - agent-flags.md (--non-interactive/--quiet etc.)
  - commands.md (Key parameters cheat sheet)
  - exit-codes.md (Error code reference)

## Why This Matters

Agent frameworks often have token budgets. Loading the full skill (~300 lines, ~4000 tokens) on every trigger is wasteful when:

1. CLI already has --help with complete, up-to-date parameters
2. Most invocations only use a few high-frequency commands
3. Detailed reference can be loaded on-demand

skill-lite guides agents to use CLI --help rather than duplicating parameter tables in the skill. This reduces token cost by ~75% and eliminates maintenance burden.

## Both Versions Coexist

skill/SKILL.md and skill-lite/ are both official versions. Users choose based on use case.

## Testing

This structure is already deployed in OpenClaw and working well.