### PR TITLE
fix(args): support global flags before command name

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -40,13 +40,34 @@ function buildSchema(options: OptionDef[]): FlagSchema {
 
 /**
  * Quick scan: collect positional (non-dash) args to determine the command path.
- * Does not consume flag values — just skips dash-prefixed tokens.
+ * Skips global flags and their values so that e.g. `--output json text chat`
+ * correctly produces ['text', 'chat'] instead of ['json', 'text', 'chat'].
  */
-export function scanCommandPath(argv: string[]): string[] {
+export function scanCommandPath(argv: string[], globalOptions: OptionDef[] = []): string[] {
+  const globalSchema = buildSchema(globalOptions);
   const path: string[] = [];
-  for (const arg of argv) {
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i]!;
     if (arg === '--') break;
-    if (!arg.startsWith('-')) path.push(arg);
+
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      const key = eqIdx !== -1 ? arg.slice(2, eqIdx) : arg.slice(2);
+      const camelKey = kebabToCamel(key);
+
+      if (!globalSchema.booleans.has(camelKey) && eqIdx === -1) {
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('-')) { i++; continue; }
+
+    path.push(arg);
+    i++;
   }
   return path;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function main() {
     process.exit(0);
   }
 
-  const commandPath = scanCommandPath(argv);
+  const commandPath = scanCommandPath(argv, GLOBAL_OPTIONS);
 
   if (argv.includes('--help') || argv.includes('-h')) {
     registry.printHelp(commandPath, process.stderr);


### PR DESCRIPTION
## Summary
- `scanCommandPath` now accepts `globalOptions` schema to correctly skip flag values before the command path
- Previously `minimax --output json text chat` would fail with "Unknown command: minimax json text chat"
- All global flags with values (`--api-key`, `--region`, `--output`, `--timeout`, `--base-url`) now work in any position

## Test plan
- [x] `minimax --output json text chat --message "hello" --dry-run` → works
- [x] `minimax --timeout 30 text chat --message "hello" --dry-run` → works  
- [x] `minimax --region cn image generate --prompt "cat" --dry-run` → works
- [x] Normal flag-after-command usage unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)