### PR TITLE
fix(auth): exempt auth status/refresh from ensureApiKey

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,8 @@ process.on('SIGINT', () => {
 const NO_AUTH_SETUP = [
   ['auth', 'login'],
   ['auth', 'logout'],
+  ['auth', 'status'],
+  ['auth', 'refresh'],
   ['config', 'show'],
   ['config', 'set'],
   ['config', 'export-schema'],


### PR DESCRIPTION
## Summary
- Add `['auth', 'status']` and `['auth', 'refresh']` to `NO_AUTH_SETUP`
- Previously, unauthenticated users running `minimax auth status` got "No API key found" instead of "Not authenticated"

## Test plan
- [x] `minimax auth status --non-interactive` (no credentials) → shows "Not authenticated"
- [x] `minimax auth status --api-key <key>` → works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)