### PR TITLE
fix(args): register --yes and --async in GLOBAL_OPTIONS

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -49,6 +49,8 @@ export const GLOBAL_OPTIONS: OptionDef[] = [
   { flag: '--no-color',          description: 'Disable ANSI colors' },
   { flag: '--dry-run',           description: 'Dry run mode' },
   { flag: '--non-interactive',   description: 'Disable interactive prompts' },
+  { flag: '--yes',               description: 'Skip confirmation prompts' },
+  { flag: '--async',             description: 'Return immediately (agent/CI mode)' },
   { flag: '--help',              description: 'Show help' },
   { flag: '--version',           description: 'Print version' },
 ];


### PR DESCRIPTION
## Summary
- `--yes` and `--async` were defined in `GlobalFlags` and used in `loadConfig` but missing from `GLOBAL_OPTIONS`
- The parser didn't know they were booleans → consumed the next argument as their value
- `minimax text chat --yes --message "hello"` would eat `--message`

## Test plan
- [x] `minimax text chat --yes --message "hello" --dry-run` → works (--message not eaten)
- [x] `minimax auth logout --yes` → no "requires a value" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)