### PR TITLE
fix(commands): detect MIME type from file extension for images

### DIFF
--- a/src/commands/image/generate.ts
+++ b/src/commands/image/generate.ts
@@ -7,7 +7,12 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { ImageRequest, ImageResponse } from '../../types/api';
 import { mkdirSync, existsSync, readFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { join, resolve, extname } from 'path';
+
+const MIME_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.png': 'image/png', '.webp': 'image/webp',
+};
 import { isInteractive } from '../../utils/env';
 import { promptText, failIfMissing } from '../../utils/prompt';
 
@@ -69,7 +74,9 @@ export default defineCommand({
         } else {
           const imgPath = resolve(params.image);
           const imgData = readFileSync(imgPath);
-          ref.image_file = `data:image/jpeg;base64,${imgData.toString('base64')}`;
+          const ext = extname(imgPath).toLowerCase();
+          const mime = MIME_TYPES[ext] || 'image/jpeg';
+          ref.image_file = `data:${mime};base64,${imgData.toString('base64')}`;
         }
       }
 

--- a/src/commands/video/generate.ts
+++ b/src/commands/video/generate.ts
@@ -10,6 +10,12 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { VideoRequest, VideoResponse, VideoTaskResponse, FileRetrieveResponse } from '../../types/api';
 import { readFileSync } from 'fs';
+import { extname } from 'path';
+
+const MIME_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.png': 'image/png', '.webp': 'image/webp',
+};
 import { isInteractive } from '../../utils/env';
 import { promptText, failIfMissing } from '../../utils/prompt';
 
@@ -63,7 +69,9 @@ export default defineCommand({
         body.first_frame_image = framePath;
       } else {
         const imgData = readFileSync(framePath);
-        body.first_frame_image = `data:image/jpeg;base64,${imgData.toString('base64')}`;
+        const ext = extname(framePath).toLowerCase();
+        const mime = MIME_TYPES[ext] || 'image/jpeg';
+        body.first_frame_image = `data:${mime};base64,${imgData.toString('base64')}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- Add MIME type detection based on file extension for `video generate --first-frame` and `image generate --subject-ref`
- Previously all local images were sent as `data:image/jpeg` regardless of actual format
- Supports: .jpg, .jpeg, .png, .webp (falls back to jpeg for unknown extensions)

## Test plan
- [x] `--first-frame test.png --dry-run` → `data:image/png;base64,...`
- [x] `--first-frame test.jpg --dry-run` → `data:image/jpeg;base64,...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)