### PR TITLE
fix(speech): remove dead --sound-effect option

### DIFF
--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -29,7 +29,6 @@ export default defineCommand({
     { flag: '--language <code>',         description: 'Language boost' },
     { flag: '--subtitles',               description: 'Include subtitle timing data' },
     { flag: '--pronunciation <from/to>', description: 'Custom pronunciation (repeatable)', type: 'array' },
-    { flag: '--sound-effect <effect>',   description: 'Add sound effect' },
     { flag: '--out <path>',              description: 'Save audio to file (uses hex decoding)' },
     { flag: '--stream',                  description: 'Stream raw audio to stdout' },
   ],


### PR DESCRIPTION
## Summary
- Remove `--sound-effect <effect>` from speech synthesize options
- The flag was defined but never wired to the request body — user input was silently discarded
- `SpeechRequest` type has no `sound_effect` field

## Test plan
- [x] `minimax speech synthesize --help` no longer shows `--sound-effect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)