### PR TITLE
fix(config): validate MINIMAX_TIMEOUT env var to prevent NaN crash

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -50,10 +50,10 @@ export function loadConfig(flags: GlobalFlags): Config {
     flags.output || process.env.MINIMAX_OUTPUT || file.output,
   );
 
-  const timeout = flags.timeout
-    ?? (process.env.MINIMAX_TIMEOUT ? Number(process.env.MINIMAX_TIMEOUT) : undefined)
-    ?? file.timeout
-    ?? 300;
+  const envTimeout = process.env.MINIMAX_TIMEOUT ? Number(process.env.MINIMAX_TIMEOUT) : undefined;
+  const validEnvTimeout = envTimeout !== undefined && Number.isFinite(envTimeout) && envTimeout > 0
+    ? envTimeout : undefined;
+  const timeout = flags.timeout ?? validEnvTimeout ?? file.timeout ?? 300;
 
   return {
     apiKey,


### PR DESCRIPTION
## Summary
- Validate `MINIMAX_TIMEOUT` env var: reject NaN, negative, and non-finite values
- Previously `MINIMAX_TIMEOUT=abc` caused `AbortSignal.timeout(NaN)` → TypeError crash
- Invalid values now silently fall back to the default 300s timeout

## Test plan
- [x] `MINIMAX_TIMEOUT=abc minimax text chat --message "hi"` → no crash, uses 300s default
- [x] `MINIMAX_TIMEOUT=30 minimax text chat --message "hi"` → uses 30s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)