### PR TITLE
fix(image): prevent URL truncation in --subject-ref parsing

### DIFF
--- a/src/commands/image/generate.ts
+++ b/src/commands/image/generate.ts
@@ -56,7 +56,11 @@ export default defineCommand({
     if (flags.subjectRef) {
       const refStr = flags.subjectRef as string;
       const params = Object.fromEntries(
-        refStr.split(',').map(p => p.split('=') as [string, string]),
+        refStr.split(',').map(p => {
+        const eqIdx = p.indexOf('=');
+        if (eqIdx === -1) return [p, ''];
+        return [p.slice(0, eqIdx), p.slice(eqIdx + 1)];
+      }),
       );
 
       const ref: { type: string; image_url?: string; image_file?: string } = {


### PR DESCRIPTION
## Summary
- Fix `--subject-ref` parsing that truncated URLs containing `=` in query params
- `image=https://x.com/img?size=large` was truncated to `https://x.com/img?size`
- Now splits only on the first `=` per key-value pair

## Test plan
- [x] `--subject-ref "type=character,image=https://x.com/a?s=large" --dry-run` → full URL preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)