### PR TITLE
fix(update): align version fallback with main.ts (0.3.1)

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from '../command';
 
-const CLI_VERSION = process.env.CLI_VERSION ?? '0.0.0';
+const CLI_VERSION = process.env.CLI_VERSION ?? '0.3.1';
 
 export default defineCommand({
   name: 'update',


### PR DESCRIPTION
## Summary
- Fix version string inconsistency: `minimax --version` showed `0.3.1` but `minimax update` showed `0.0.0`
- Align fallback in `update.ts` from `'0.0.0'` to `'0.3.1'`

## Test plan
- [x] `minimax --version` → `minimax 0.3.1`
- [x] `minimax update` → `Current version: 0.3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)