### PR TITLE
fix(stream): decode SSE/hex audio for --stream and handle EPIPE

### DIFF
--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -6,7 +6,7 @@ import { musicEndpoint } from '../../client/endpoints';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { readTextFromPathOrStdin } from '../../utils/fs';
-import { pipeAudioSseToStdout } from '../../utils/audio-stream';
+import { pipeAudioSseToStdout, NoResponseBodyError } from '../../utils/audio-stream';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { MusicRequest, MusicResponse } from '../../types/api';
@@ -151,9 +151,9 @@ export default defineCommand({
     if (flags.stream) {
       const res = await request(config, { url, method: 'POST', body, stream: true });
       try {
-        await pipeAudioSseToStdout(res.body);
+        await pipeAudioSseToStdout(res);
       } catch (err) {
-        if (err instanceof Error && err.message === 'No response body') {
+        if (err instanceof NoResponseBodyError) {
           throw new CLIError('No response body', ExitCode.GENERAL);
         }
         throw err;

--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -6,6 +6,7 @@ import { musicEndpoint } from '../../client/endpoints';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { readTextFromPathOrStdin } from '../../utils/fs';
+import { pipeAudioSseToStdout } from '../../utils/audio-stream';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { MusicRequest, MusicResponse } from '../../types/api';
@@ -149,14 +150,14 @@ export default defineCommand({
 
     if (flags.stream) {
       const res = await request(config, { url, method: 'POST', body, stream: true });
-      const reader = res.body?.getReader();
-      if (!reader) throw new CLIError('No response body', ExitCode.GENERAL);
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        process.stdout.write(value);
+      try {
+        await pipeAudioSseToStdout(res.body);
+      } catch (err) {
+        if (err instanceof Error && err.message === 'No response body') {
+          throw new CLIError('No response body', ExitCode.GENERAL);
+        }
+        throw err;
       }
-      reader.releaseLock();
       return;
     }
 

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -6,6 +6,7 @@ import { speechEndpoint } from '../../client/endpoints';
 import { detectOutputFormat, formatOutput } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { readTextFromPathOrStdin } from '../../utils/fs';
+import { pipeAudioSseToStdout } from '../../utils/audio-stream';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { SpeechRequest, SpeechResponse } from '../../types/api';
@@ -98,14 +99,14 @@ export default defineCommand({
 
     if (flags.stream) {
       const res = await request(config, { url, method: 'POST', body, stream: true });
-      const reader = res.body?.getReader();
-      if (!reader) throw new CLIError('No response body', ExitCode.GENERAL);
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        process.stdout.write(value);
+      try {
+        await pipeAudioSseToStdout(res.body);
+      } catch (err) {
+        if (err instanceof Error && err.message === 'No response body') {
+          throw new CLIError('No response body', ExitCode.GENERAL);
+        }
+        throw err;
       }
-      reader.releaseLock();
       return;
     }
 

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -6,7 +6,7 @@ import { speechEndpoint } from '../../client/endpoints';
 import { detectOutputFormat, formatOutput } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { readTextFromPathOrStdin } from '../../utils/fs';
-import { pipeAudioSseToStdout } from '../../utils/audio-stream';
+import { pipeAudioSseToStdout, NoResponseBodyError } from '../../utils/audio-stream';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { SpeechRequest, SpeechResponse } from '../../types/api';
@@ -100,9 +100,9 @@ export default defineCommand({
     if (flags.stream) {
       const res = await request(config, { url, method: 'POST', body, stream: true });
       try {
-        await pipeAudioSseToStdout(res.body);
+        await pipeAudioSseToStdout(res);
       } catch (err) {
-        if (err instanceof Error && err.message === 'No response body') {
+        if (err instanceof NoResponseBodyError) {
           throw new CLIError('No response body', ExitCode.GENERAL);
         }
         throw err;

--- a/src/utils/audio-stream.ts
+++ b/src/utils/audio-stream.ts
@@ -5,16 +5,45 @@
  * envelopes whose `data.audio` field is a hex-encoded chunk of the target
  * audio format. The `--stream` CLI flag is documented as writing *raw audio*
  * to stdout (so it can be piped directly into players such as `mpv -`), so
- * this helper parses the SSE frames, decodes the hex payloads, and writes
+ * this helper consumes the SSE stream, decodes the hex payloads, and writes
  * the decoded bytes to stdout.
+ *
+ * The stream contains N incremental chunk events followed by a terminal
+ * "summary" event that re-sends the full audio plus metadata (this is what
+ * `--out` saves). The summary must be skipped in streaming mode, otherwise
+ * the complete file gets appended after the incremental frames and the
+ * resulting MP3 contains duplicated audio with broken framing. The summary
+ * is identified by the presence of a top-level `extra_info` field — note
+ * that `trace_id` is on every event, so it cannot be used as the
+ * discriminator.
  */
 
+import { parseSSE } from '../client/stream';
+
+/** Thrown when the upstream response has no body to stream from. */
+export class NoResponseBodyError extends Error {
+  constructor() {
+    super('No response body');
+    this.name = 'NoResponseBodyError';
+  }
+}
+
+interface SseEnvelope {
+  data?: { audio?: string; status?: number };
+  extra_info?: unknown;
+  trace_id?: string;
+}
+
+let stdoutEpipeHandlerInstalled = false;
+
 /**
- * Install a one-shot EPIPE handler on stdout so that downstream consumers
- * closing the pipe early (e.g. `... | head`, or a player that exits) does
- * not crash the process with an unhandled `'error'` event.
+ * Install (idempotently) an EPIPE handler on stdout so that downstream
+ * consumers closing the pipe early (e.g. `... | head`, or a player that
+ * exits) cause a clean exit instead of an unhandled `'error'` event.
  */
 export function installStdoutEpipeHandler(): void {
+  if (stdoutEpipeHandlerInstalled) return;
+  stdoutEpipeHandlerInstalled = true;
   process.stdout.on('error', (err: NodeJS.ErrnoException) => {
     if (err && err.code === 'EPIPE') {
       process.exit(0);
@@ -24,82 +53,40 @@ export function installStdoutEpipeHandler(): void {
 }
 
 /**
- * Consume a fetch-style ReadableStream of SSE bytes and write the decoded
- * raw audio bytes (from `data.audio` hex fields) to stdout.
+ * Consume a fetch-style SSE response and write the decoded raw audio bytes
+ * (from `data.audio` hex fields) to stdout, honoring backpressure.
+ *
+ * @throws {NoResponseBodyError} if `response.body` is missing.
  */
-export async function pipeAudioSseToStdout(
-  body: ReadableStream<Uint8Array> | null | undefined,
-): Promise<void> {
-  const reader = body?.getReader();
-  if (!reader) {
-    throw new Error('No response body');
+export async function pipeAudioSseToStdout(response: Response): Promise<void> {
+  if (!response.body) {
+    throw new NoResponseBodyError();
   }
 
   installStdoutEpipeHandler();
 
-  const decoder = new TextDecoder();
-  let buffer = '';
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-
-      // SSE events are separated by blank lines.
-      let sep: number;
-      while ((sep = buffer.indexOf('\n\n')) >= 0) {
-        const event = buffer.slice(0, sep);
-        buffer = buffer.slice(sep + 2);
-        writeEvent(event);
-      }
-    }
-
-    // Flush any trailing event without a terminating blank line.
-    buffer += decoder.decode();
-    if (buffer.length > 0) {
-      writeEvent(buffer);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-interface SseEnvelope {
-  data?: { audio?: string; status?: number };
-  // `extra_info` is only present on the terminal "summary" event, which
-  // re-sends the full audio plus metadata. We must skip that event in
-  // streaming mode, otherwise the complete file gets appended after the
-  // incremental frames and the resulting MP3 contains duplicated audio
-  // with broken framing. (Note: every event carries `trace_id`, so it
-  // can't be used as the discriminator.)
-  extra_info?: unknown;
-  trace_id?: string;
-}
-
-function writeEvent(event: string): void {
-  for (const rawLine of event.split('\n')) {
-    if (!rawLine.startsWith('data:')) continue;
-    // Per SSE spec, an optional single space after `data:` should be stripped.
-    const payload = rawLine.slice(5).replace(/^ /, '');
+  for await (const event of parseSSE(response)) {
+    const payload = event.data;
     if (!payload || payload === '[DONE]') continue;
 
     let parsed: SseEnvelope;
     try {
       parsed = JSON.parse(payload) as SseEnvelope;
     } catch {
-      // Non-JSON keepalive or comment — skip.
+      // Non-JSON keepalive — skip.
       continue;
     }
 
     // Skip the terminal summary event (it re-sends the entire audio).
-    if (parsed.extra_info !== undefined) {
-      continue;
-    }
+    if (parsed.extra_info !== undefined) continue;
 
-    const hex = parsed?.data?.audio;
-    if (typeof hex === 'string' && hex.length > 0) {
-      process.stdout.write(Buffer.from(hex, 'hex'));
+    const hex = parsed.data?.audio;
+    if (typeof hex !== 'string' || hex.length === 0) continue;
+
+    const chunk = Buffer.from(hex, 'hex');
+    if (!process.stdout.write(chunk)) {
+      // Honor backpressure: pause until stdout drains.
+      await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
     }
   }
 }

--- a/src/utils/audio-stream.ts
+++ b/src/utils/audio-stream.ts
@@ -1,0 +1,88 @@
+/**
+ * Helpers for piping streamed TTS / music responses to stdout as raw audio.
+ *
+ * The MiniMax streaming endpoints return a Server-Sent Events stream of JSON
+ * envelopes whose `data.audio` field is a hex-encoded chunk of the target
+ * audio format. The `--stream` CLI flag is documented as writing *raw audio*
+ * to stdout (so it can be piped directly into players such as `mpv -`), so
+ * this helper parses the SSE frames, decodes the hex payloads, and writes
+ * the decoded bytes to stdout.
+ */
+
+/**
+ * Install a one-shot EPIPE handler on stdout so that downstream consumers
+ * closing the pipe early (e.g. `... | head`, or a player that exits) does
+ * not crash the process with an unhandled `'error'` event.
+ */
+export function installStdoutEpipeHandler(): void {
+  process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    if (err && err.code === 'EPIPE') {
+      process.exit(0);
+    }
+    throw err;
+  });
+}
+
+/**
+ * Consume a fetch-style ReadableStream of SSE bytes and write the decoded
+ * raw audio bytes (from `data.audio` hex fields) to stdout.
+ */
+export async function pipeAudioSseToStdout(
+  body: ReadableStream<Uint8Array> | null | undefined,
+): Promise<void> {
+  const reader = body?.getReader();
+  if (!reader) {
+    throw new Error('No response body');
+  }
+
+  installStdoutEpipeHandler();
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE events are separated by blank lines.
+      let sep: number;
+      while ((sep = buffer.indexOf('\n\n')) >= 0) {
+        const event = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        writeEvent(event);
+      }
+    }
+
+    // Flush any trailing event without a terminating blank line.
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      writeEvent(buffer);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function writeEvent(event: string): void {
+  for (const rawLine of event.split('\n')) {
+    if (!rawLine.startsWith('data:')) continue;
+    // Per SSE spec, an optional single space after `data:` should be stripped.
+    const payload = rawLine.slice(5).replace(/^ /, '');
+    if (!payload || payload === '[DONE]') continue;
+
+    let parsed: { data?: { audio?: string } };
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      // Non-JSON keepalive or comment — skip.
+      continue;
+    }
+
+    const hex = parsed?.data?.audio;
+    if (typeof hex === 'string' && hex.length > 0) {
+      process.stdout.write(Buffer.from(hex, 'hex'));
+    }
+  }
+}

--- a/src/utils/audio-stream.ts
+++ b/src/utils/audio-stream.ts
@@ -65,6 +65,18 @@ export async function pipeAudioSseToStdout(
   }
 }
 
+interface SseEnvelope {
+  data?: { audio?: string; status?: number };
+  // `extra_info` is only present on the terminal "summary" event, which
+  // re-sends the full audio plus metadata. We must skip that event in
+  // streaming mode, otherwise the complete file gets appended after the
+  // incremental frames and the resulting MP3 contains duplicated audio
+  // with broken framing. (Note: every event carries `trace_id`, so it
+  // can't be used as the discriminator.)
+  extra_info?: unknown;
+  trace_id?: string;
+}
+
 function writeEvent(event: string): void {
   for (const rawLine of event.split('\n')) {
     if (!rawLine.startsWith('data:')) continue;
@@ -72,11 +84,16 @@ function writeEvent(event: string): void {
     const payload = rawLine.slice(5).replace(/^ /, '');
     if (!payload || payload === '[DONE]') continue;
 
-    let parsed: { data?: { audio?: string } };
+    let parsed: SseEnvelope;
     try {
-      parsed = JSON.parse(payload);
+      parsed = JSON.parse(payload) as SseEnvelope;
     } catch {
       // Non-JSON keepalive or comment — skip.
+      continue;
+    }
+
+    // Skip the terminal summary event (it re-sends the entire audio).
+    if (parsed.extra_info !== undefined) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #54.

- `speech synthesize --stream` and `music generate --stream` now write **decoded raw audio bytes** to stdout, matching the documentation and making the existing `| mpv --no-terminal -` example actually work. Previously they wrote the upstream SSE stream verbatim (`data: {"data":{"audio":"<hex>"}}` envelopes), so any audio player saw garbage and bailed with "Failed to recognize file format".
- A new shared helper `src/utils/audio-stream.ts` (`pipeAudioSseToStdout`) parses SSE frames, JSON-decodes each `data:` line, hex-decodes `data.audio`, and writes the bytes to stdout. Buffers across chunk boundaries so partial events are handled correctly.
- The same helper installs an `EPIPE` handler on `process.stdout`, so consumers closing the pipe early (`... | head`, a player that exits, or `mpv` not being installed) result in a clean `exit(0)` instead of an unhandled `'error'` event and Node stack trace.
- Both `commands/speech/synthesize.ts` and `commands/music/generate.ts` had the same bug; both now use the shared helper.

## Test plan

Built locally with `bun run build` and verified against the live API:

- [x] `mmx speech synthesize --text "..." --stream > out.mp3` produces a valid MP3 (`file` reports `ID3 v2.4 / MPEG ADTS layer III, 128 kbps, 32 kHz`).
- [x] `mmx speech synthesize --text "..." --stream | mpv --no-terminal -` plays correctly end-to-end.
- [x] `mmx speech synthesize --text "..." --stream | head -c 5 > /dev/null` exits 0 with no EPIPE crash.
- [ ] Music streaming path uses the same helper; would appreciate a maintainer sanity-check against a real `music generate --stream` call since I only smoke-tested speech.

## Notes

- The SSE parser tolerates `[DONE]` sentinels, comment/keepalive lines, and the optional single space after `data:` per the SSE spec.
- No changes to flags, defaults, or non-stream code paths.