### PR TITLE
fix(quota): correct reversed used/remaining values in quiet mode

### DIFF
--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -37,8 +37,9 @@ export default defineCommand({
 
     if (config.quiet) {
       for (const m of models) {
-        const remaining = m.current_interval_total_count - m.current_interval_usage_count;
-        console.log(`${m.model_name}\t${m.current_interval_usage_count}\t${m.current_interval_total_count}\t${remaining}`);
+        const remaining = m.current_interval_usage_count;
+        const used = Math.max(0, m.current_interval_total_count - remaining);
+        console.log(`${m.model_name}\t${used}\t${m.current_interval_total_count}\t${remaining}`);
       }
       return;
     }


### PR DESCRIPTION
## Summary

- Fix `mmx quota show --quiet` outputting reversed used/remaining values
- The API field `current_interval_usage_count` returns **remaining** counts (not used), consistent with the `model_remains` wrapper name
- Quiet mode was double-subtracting: `remaining = total - usage_count`, treating `usage_count` as "used" when it's actually "remaining"
- The rich text table (`quota-table.ts`) already handled this correctly; only the quiet TSV path had the bug

**Before** (usage_count=1497, total=1500):
```
MiniMax-M*    1497    1500    3     ← columns reversed
```

**After**:
```
MiniMax-M*    3    1500    1497    ← correct: used=3, total=1500, remaining=1497
```

Fixes #53

## Test plan

- [ ] Run `mmx quota show --quiet` and verify used/remaining columns are correct
- [ ] Run `mmx quota show --output text` and confirm rich table is unchanged
- [ ] Run `mmx quota show --output json` and cross-check raw values

🤖 Generated with [Claude Code](https://claude.com/claude-code)