### PR TITLE
fix(speech): decode SSE stream to raw audio and handle EPIPE

### DIFF
--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -3,6 +3,7 @@ import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
 import { request, requestJson } from '../../client/http';
 import { speechEndpoint } from '../../client/endpoints';
+import { parseSSE } from '../../client/stream';
 import { detectOutputFormat, formatOutput } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { readTextFromPathOrStdin } from '../../utils/fs';
@@ -98,14 +99,14 @@ export default defineCommand({
 
     if (flags.stream) {
       const res = await request(config, { url, method: 'POST', body, stream: true });
-      const reader = res.body?.getReader();
-      if (!reader) throw new CLIError('No response body', ExitCode.GENERAL);
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        process.stdout.write(value);
+      for await (const event of parseSSE(res)) {
+        if (!event.data || event.data === '[DONE]') break;
+        const parsed = JSON.parse(event.data);
+        const audioHex = parsed?.data?.audio;
+        if (audioHex) {
+          process.stdout.write(Buffer.from(audioHex, 'hex'));
+        }
       }
-      reader.releaseLock();
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,12 @@ process.on('SIGINT', () => {
   process.exit(130);
 });
 
+// Handle stdout EPIPE gracefully (e.g., piped to `mpv` that exits early)
+process.stdout.on('error', (e) => {
+  if (e.code === 'EPIPE') process.exit(0);
+  else throw e;
+});
+
 // Commands that manage their own auth or need no key
 const NO_AUTH_SETUP = [
   ['auth', 'login'],


### PR DESCRIPTION
## Summary

Two fixes for `mmx speech synthesize --stream`:

### 1. SSE stream now outputs decoded binary audio

`--stream` was writing raw SSE/JSON/hex text to stdout. It now:
- Parses SSE events via `parseSSE()`
- Extracts `.data.audio` (hex string) from each event's JSON
- Hex-decodes to raw binary MP3 and writes to stdout

This makes the documented example actually work:
```bash
mmx speech synthesize --text "Hello" --stream | mpv --no-terminal -
```

### 2. EPIPE no longer crashes the process

Added `stdout.on('error')` handler in `main.ts`. When a downstream process (e.g. `mpv`, `head`) exits early and closes the pipe, `EPIPE` is now treated as normal pipe-close with exit code 0, instead of an unhandled exception that crashes the CLI.

**Before**: `Error: write EPIPE` — unhandled, process exits with non-zero code
**After**: exit code 0

Fixes #54

## Test plan

- [ ] `mmx speech synthesize --text "Test" --stream | head -c 4` — first bytes should be `ID3` (valid MP3)
- [ ] `mmx speech synthesize --text "Test" --stream | head -c 1; echo $?` — should print `0`
- [ ] `mmx speech synthesize --text "Test" --out /tmp/out.mp3` — non-stream path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)