### PR TITLE
fix(speech): use correct file extension for default output filename

### DIFF
--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -56,7 +56,8 @@ export default defineCommand({
     const model = (flags.model as string) || 'speech-2.8-hd';
     const voice = (flags.voice as string) || 'English_expressive_narrator';
     const ts = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
-    const outPath = (flags.out as string | undefined) ?? `speech_${ts}.mp3`;
+    const ext = (flags.format as string) || 'mp3';
+    const outPath = (flags.out as string | undefined) ?? `speech_${ts}.${ext}`;
     const outFormat = 'hex';
     const format = detectOutputFormat(config.output);
 


### PR DESCRIPTION
## Problem

When `--format` is specified without `--out`, the default output filename always used `.mp3` regardless of the requested format:

```bash
mmx speech synthesize --text "Hello" --format wav
# Produces: speech_2026-04-09-07-15-14.mp3
# Actual content: RIFF WAVE audio
```

This means the file extension does not match the actual audio format. Tools that rely on file extensions (ffmpeg, audio editors, upload APIs, scripts) will misidentify or fail to process the file.

## Fix

Derive the extension from the `--format` flag, defaulting to `mp3` when not specified:

```ts
// Before
const outPath = (flags.out as string | undefined) ?? `speech_${ts}.mp3`;

// After
const ext = (flags.format as string) || 'mp3';
const outPath = (flags.out as string | undefined) ?? `speech_${ts}.${ext}`;
```

This only affects the auto-generated filename. Users who explicitly pass `--out <path>` are unaffected.

Note: `music/generate.ts` already handles this correctly — this brings `speech/synthesize.ts` in line with the same pattern.

## Reproduction

```bash
mmx speech synthesize --text "hi" --format wav
file speech_*.mp3   # RIFF WAVE audio — extension mismatch
```

After fix:

```bash
mmx speech synthesize --text "hi" --format wav
# Produces: speech_xxx.wav  ✓
```