### PR TITLE
feat(docs): add mmx help command + API doc links to --help

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,39 @@
+import { defineCommand } from '../command';
+import type { Config } from '../config/schema';
+import type { GlobalFlags } from '../types/flags';
+
+interface ApiRef {
+  command: string;
+  title: string;
+  url: string;
+}
+
+const API_REFS: ApiRef[] = [
+  { command: 'mmx text chat',            title: 'Text Generation (Chat Completion)',    url: 'https://platform.minimax.io/docs/api-reference/text-post' },
+  { command: 'mmx speech synthesize',    title: 'Speech T2A (Text-to-Audio)',           url: 'https://platform.minimax.io/docs/api-reference/speech-t2a-http' },
+  { command: 'mmx image generate',       title: 'Image Generation (T2I / I2I)',         url: 'https://platform.minimax.io/docs/api-reference/image-generation-t2i' },
+  { command: 'mmx video generate',       title: 'Video Generation (T2V / I2V / S2V)',   url: 'https://platform.minimax.io/docs/api-reference/video-generation' },
+  { command: 'mmx music generate',       title: 'Music Generation',                     url: 'https://platform.minimax.io/docs/api-reference/music-generation' },
+  { command: 'mmx music cover',          title: 'Music Cover (via Music Generation)',   url: 'https://platform.minimax.io/docs/api-reference/music-generation' },
+  { command: 'mmx search query',         title: 'Web Search',                           url: 'https://platform.minimax.io/docs/api-reference/web-search' },
+  { command: 'mmx vision describe',      title: 'Vision (Image Understanding)',         url: 'https://platform.minimax.io/docs/api-reference/vision' },
+];
+
+export default defineCommand({
+  name: 'help',
+  description: 'Show MiniMax API documentation links',
+  usage: 'mmx help',
+  apiDocs: 'https://platform.minimax.io/docs/api-reference',
+  async run(_config: Config, _flags: GlobalFlags) {
+    process.stdout.write(`
+MiniMax API Documentation Links
+
+  Official docs: https://platform.minimax.io/docs/api-reference
+
+`);
+    for (const ref of API_REFS) {
+      process.stdout.write(`  ${ref.command.padEnd(30)} ${ref.title}\n`);
+      process.stdout.write(`  ${' '.repeat(30)} ${ref.url}\n\n`);
+    }
+  },
+});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,39 +1,40 @@
 import { defineCommand } from '../command';
+import { DOCS_HOSTS } from '../config/schema';
 import type { Config } from '../config/schema';
 import type { GlobalFlags } from '../types/flags';
 
 interface ApiRef {
   command: string;
   title: string;
-  url: string;
+  path: string;
 }
 
 const API_REFS: ApiRef[] = [
-  { command: 'mmx text chat',            title: 'Text Generation (Chat Completion)',    url: 'https://platform.minimax.io/docs/api-reference/text-post' },
-  { command: 'mmx speech synthesize',    title: 'Speech T2A (Text-to-Audio)',           url: 'https://platform.minimax.io/docs/api-reference/speech-t2a-http' },
-  { command: 'mmx image generate',       title: 'Image Generation (T2I / I2I)',         url: 'https://platform.minimax.io/docs/api-reference/image-generation-t2i' },
-  { command: 'mmx video generate',       title: 'Video Generation (T2V / I2V / S2V)',   url: 'https://platform.minimax.io/docs/api-reference/video-generation' },
-  { command: 'mmx music generate',       title: 'Music Generation',                     url: 'https://platform.minimax.io/docs/api-reference/music-generation' },
-  { command: 'mmx music cover',          title: 'Music Cover (via Music Generation)',   url: 'https://platform.minimax.io/docs/api-reference/music-generation' },
-  { command: 'mmx search query',         title: 'Web Search',                           url: 'https://platform.minimax.io/docs/api-reference/web-search' },
-  { command: 'mmx vision describe',      title: 'Vision (Image Understanding)',         url: 'https://platform.minimax.io/docs/api-reference/vision' },
+  { command: 'mmx text chat',            title: 'Text Generation (Chat Completion)',    path: '/docs/api-reference/text-post' },
+  { command: 'mmx speech synthesize',    title: 'Speech T2A (Text-to-Audio)',           path: '/docs/api-reference/speech-t2a-http' },
+  { command: 'mmx image generate',       title: 'Image Generation (T2I / I2I)',         path: '/docs/api-reference/image-generation-t2i' },
+  { command: 'mmx video generate',       title: 'Video Generation (T2V / I2V / S2V)',   path: '/docs/api-reference/video-generation' },
+  { command: 'mmx music generate',       title: 'Music Generation',                     path: '/docs/api-reference/music-generation' },
+  { command: 'mmx music cover',          title: 'Music Cover (via Music Generation)',   path: '/docs/api-reference/music-generation' },
+  { command: 'mmx search query',         title: 'Web Search',                           path: '/docs/api-reference/web-search' },
+  { command: 'mmx vision describe',      title: 'Vision (Image Understanding)',         path: '/docs/api-reference/vision' },
 ];
 
 export default defineCommand({
   name: 'help',
   description: 'Show MiniMax API documentation links',
   usage: 'mmx help',
-  apiDocs: 'https://platform.minimax.io/docs/api-reference',
-  async run(_config: Config, _flags: GlobalFlags) {
+  async run(config: Config, _flags: GlobalFlags) {
+    const host = DOCS_HOSTS[config.region] || DOCS_HOSTS.global;
     process.stdout.write(`
 MiniMax API Documentation Links
 
-  Official docs: https://platform.minimax.io/docs/api-reference
+  Official docs: ${host}/docs/api-reference
 
 `);
     for (const ref of API_REFS) {
       process.stdout.write(`  ${ref.command.padEnd(30)} ${ref.title}\n`);
-      process.stdout.write(`  ${' '.repeat(30)} ${ref.url}\n\n`);
+      process.stdout.write(`  ${' '.repeat(30)} ${host}${ref.path}\n\n`);
     }
   },
 });

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -14,6 +14,7 @@ import type { SpeechRequest, SpeechResponse } from '../../types/api';
 export default defineCommand({
   name: 'speech synthesize',
   description: 'Synchronous TTS, up to 10k chars (speech-2.8-hd / 2.6 / 02)',
+  apiDocs: '/docs/api-reference/speech-t2a-http',
   usage: 'mmx speech synthesize --text <text> [--out <path>] [flags]',
   options: [
     { flag: '--model <model>',           description: 'Model ID (default: speech-2.8-hd)' },

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -78,6 +78,7 @@ function extractText(content: ContentBlock[]): string {
 export default defineCommand({
   name: 'text chat',
   description: 'Send a chat completion (MiniMax Messages API)',
+  apiDocs: 'https://platform.minimax.io/docs/api-reference/text-post',
   usage: 'mmx text chat --message <text> [flags]',
   options: [
     { flag: '--model <model>', description: 'Model ID (default: MiniMax-M2.7)' },

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -78,7 +78,7 @@ function extractText(content: ContentBlock[]): string {
 export default defineCommand({
   name: 'text chat',
   description: 'Send a chat completion (MiniMax Messages API)',
-  apiDocs: 'https://platform.minimax.io/docs/api-reference/text-post',
+  apiDocs: '/docs/api-reference/text-post',
   usage: 'mmx text chat --message <text> [flags]',
   options: [
     { flag: '--model <model>', description: 'Model ID (default: MiniMax-M2.7)' },

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -23,6 +23,7 @@ import configShow from './commands/config/show';
 import configSet from './commands/config/set';
 import configExportSchema from './commands/config/export-schema';
 import update from './commands/update';
+import help from './commands/help';
 
 export type { Command, OptionDef } from './command';
 
@@ -282,4 +283,5 @@ export const registry = new CommandRegistry({
   'config set':           configSet,
   'config export-schema': configExportSchema,
   'update':               update,
+  'help':                 help,
 });


### PR DESCRIPTION
## Changes

- **`mmx help`**: New command listing all official MiniMax API documentation links
- **API Reference in --help**: Every command's --help now shows its official API doc URL at the bottom
- **Updated model lists in --help**:
  - text chat: all 7 models (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed, M2.1, M2, Text-01)
  - speech synthesize: all 8 models (speech-2.8/2.6/02/01, each with hd/turbo)
  - image generate: image-01 / image-01-live
  - video generate: Hailuo-2.3 / 2.3-Fast / Hailuo-02

### Files
- `src/commands/help.ts` (new)
- `src/registry.ts` (register help, display apiDocs)
- `src/command.ts` (apiDocs interface)
- `src/commands/text/chat.ts`
- `src/commands/speech/synthesize.ts`
- `src/commands/image/generate.ts`
- `src/commands/video/generate.ts`
- `src/commands/music/generate.ts`