### PR TITLE
docs: fix video --download example and clarify auth credential locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ mmx image generate --prompt "Logo" --out-dir ./out/
 ### `mmx video`
 
 ```bash
-mmx video generate --prompt "Ocean waves at sunset" --async
-mmx video generate --prompt "A robot painting" --download sunset.mp4
+mmx video generate --prompt "Ocean waves at sunset" --download sunset.mp4
+mmx video generate --prompt "A robot painting" --async
 mmx video task get --task-id 123456
 mmx video download --file-id 176844028768320 --out video.mp4
 ```
@@ -136,6 +136,10 @@ mmx auth status
 mmx auth refresh
 mmx auth logout
 ```
+
+`mmx auth status` is the canonical way to verify active authentication.
+`~/.mmx/credentials.json` exists only for OAuth login. API-key login persists to
+`~/.mmx/config.json` (and `--api-key` can also be passed per command).
 
 ### `mmx config` · `mmx quota`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -82,8 +82,8 @@ mmx image generate --prompt "山水画" --out-dir ./output/
 ### `mmx video`
 
 ```bash
-mmx video generate --prompt "海浪拍打礁石" --async
-mmx video generate --prompt "机器人作画" --download sunset.mp4
+mmx video generate --prompt "海浪拍打礁石" --download sunset.mp4
+mmx video generate --prompt "机器人作画" --async
 mmx video task get --task-id 123456
 mmx video download --file-id 176844028768320 --out video.mp4
 ```
@@ -136,6 +136,10 @@ mmx auth status
 mmx auth refresh
 mmx auth logout
 ```
+
+请使用 `mmx auth status` 作为认证状态的权威检查方式。`~/.mmx/credentials.json`
+只在 OAuth 登录时存在；API Key 登录会写入 `~/.mmx/config.json`（也可每次通过
+`--api-key` 直接传入）。
 
 ### `mmx config` · `mmx quota`
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -13,8 +13,11 @@ Use `mmx` to generate text, images, video, speech, music, and perform web search
 # Install
 npm install -g mmx-cli
 
-# Auth (persisted to ~/.mmx/credentials.json)
+# Auth (OAuth persists to ~/.mmx/credentials.json, API key persists to ~/.mmx/config.json)
 mmx auth login --api-key sk-xxxxx
+
+# Verify active auth source
+mmx auth status
 
 # Or pass per-call
 mmx text chat --api-key sk-xxxxx --message "Hello"


### PR DESCRIPTION
## Summary
- fix misleading `mmx video generate --download` docs example by aligning prompt and output filename
- add auth troubleshooting clarification in English and Chinese READMEs
- document that OAuth uses `~/.mmx/credentials.json`, while API-key login persists to `~/.mmx/config.json`
- update skill guide auth section to use `mmx auth status` as canonical verification

## Issues addressed
- Fixes MiniMax-AI/cli#62
- Fixes MiniMax-AI/cli#80

## Testing
- documentation-only changes
