### PR TITLE
docs: fix misleading auth file references (#80)

### DIFF
--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -54,12 +54,10 @@ mmx
 Credential resolution order:
 1. `--api-key` flag (highest priority)
 2. `~/.mmx/credentials.json` (OAuth token — only created by `mmx auth login` without `--api-key`)
-3. `fileApiKey` in `~/.mmx/config.json` (persisted API key)
-4. `$MINIMAX_API_KEY` env var
+3. `fileApiKey` in `~/.mmx/config.json` (persisted API key from a previous `mmx auth login --api-key`)
 
-If none are found, the CLI returns `No credentials found`. The CLI can be fully authenticated
-using any single method — `~/.mmx/credentials.json` is **not required** if you use an API key
-instead.
+If none are found, the CLI returns `No credentials found`. The `~/.mmx/credentials.json` file
+is **not required** when using API key auth — it is only created during OAuth login.
 
 ## Configuration
 

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -52,10 +52,14 @@ mmx
 ## Authentication
 
 Credential resolution order:
-1. `--api-key` flag
-2. `$MINIMAX_API_KEY` env var
-3. `~/.mmx/credentials.json` (OAuth)
-4. `api_key` in `~/.mmx/config.yaml`
+1. `--api-key` flag (highest priority)
+2. `~/.mmx/credentials.json` (OAuth token — only created by `mmx auth login` without `--api-key`)
+3. `fileApiKey` in `~/.mmx/config.json` (persisted API key)
+4. `$MINIMAX_API_KEY` env var
+
+If none are found, the CLI returns `No credentials found`. The CLI can be fully authenticated
+using any single method — `~/.mmx/credentials.json` is **not required** if you use an API key
+instead.
 
 ## Configuration
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -13,10 +13,13 @@ Use `mmx` to generate text, images, video, speech, music, and perform web search
 # Install
 npm install -g mmx-cli
 
-# Auth (persisted to ~/.mmx/credentials.json)
+# Auth — API key (persisted to ~/.mmx/config.json)
 mmx auth login --api-key sk-xxxxx
 
-# Or pass per-call
+# Auth — OAuth (persisted to ~/.mmx/credentials.json)
+mmx auth login
+
+# Or pass per-call (no file needed)
 mmx text chat --api-key sk-xxxxx --message "Hello"
 ```
 


### PR DESCRIPTION
## Summary

Fixes #80 — the docs previously implied that `~/.mmx/credentials.json` is the only auth storage location, which misleads users who authenticate via API key instead.

## Changes

- **SKILL.md**: Clarified that API key auth persists to `~/.mmx/config.json`, while OAuth persists to `~/.mmx/credentials.json`.
- **docs/cli-design.md**: Rewrote the auth section to explicitly state that `credentials.json` is **not required** when using API key auth, and documented the full credential resolution order.

## Why this matters

Users and agents troubleshooting auth issues would look for `credentials.json`, conclude auth is missing, and debug the wrong thing. This change makes the docs accurate for all auth methods.