### PR TITLE
fix: correct quota quiet output calculation for misleading API field naming (#70)

### DIFF
--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -37,8 +37,11 @@ export default defineCommand({
 
     if (config.quiet) {
       for (const m of models) {
-        const remaining = m.current_interval_total_count - m.current_interval_usage_count;
-        console.log(`${m.model_name}\t${m.current_interval_usage_count}\t${m.current_interval_total_count}\t${remaining}`);
+        // NOTE: current_interval_usage_count is misleadingly named by the API —
+        // it represents REMAINING count, not used. See issue #70.
+        const remaining = m.current_interval_usage_count;
+        const used = Math.max(0, m.current_interval_total_count - remaining);
+        console.log(`${m.model_name}\t${used}\t${m.current_interval_total_count}\t${remaining}`);
       }
       return;
     }

--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -114,10 +114,13 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
   for (const m of models) {
     console.log(boxLine(W, '├', '─', '┤', useColor));
 
+    // NOTE: current_interval_usage_count is misleadingly named by the API —
+    // it represents REMAINING count, not used. See issue #70.
     const remaining = m.current_interval_usage_count;
     const limit = m.current_interval_total_count;
     const used = Math.max(0, limit - remaining);
     const usedPct = limit > 0 ? Math.round((used / limit) * 100) : 0;
+    // Same misleading naming for weekly.
     const weekRemaining = m.current_weekly_usage_count;
     const weekLimit = m.current_weekly_total_count;
     const weekUsed = Math.max(0, weekLimit - weekRemaining);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -257,8 +257,10 @@ export interface QuotaModelRemain {
   end_time: number;
   remains_time: number;
   current_interval_total_count: number;
+  /** @deprecated Misleading API naming: this represents REMAINING count, not usage. */
   current_interval_usage_count: number;
   current_weekly_total_count: number;
+  /** @deprecated Misleading API naming: this represents REMAINING count, not usage. */
   current_weekly_usage_count: number;
   weekly_start_time: number;
   weekly_end_time: number;


### PR DESCRIPTION
## Summary

Fixes #70 — the API returns `current_interval_usage_count` as the **remaining** count, not the used count. The table rendering (`quota-table.ts`) already handles this correctly, but the `--quiet` output was computing it backwards.

## Changes

- **src/commands/quota/show.ts**: Fix quiet output calculation: `used = total - remaining` instead of `remaining = total - usage_count`
- **src/output/quota-table.ts**: Add clarifying comment explaining the misleading API field naming
- **src/types/api.ts**: Add `@deprecated` JSDoc notes on the two misleading field names

## Impact

Users relying on `mmx quota show --quiet` tab-separated output were getting the used count in the 'remaining' position. This is now corrected.

The text table rendering (`mmx quota show`) was already correct — this change only affects the machine-parseable quiet mode output.