### PR TITLE
docs: add per-modality default model configuration to skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ mmx auth logout
 mmx quota
 mmx config show
 mmx config set --key region --value cn
+mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
 mmx config export-schema | jq .
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -143,6 +143,7 @@ mmx auth logout
 mmx quota
 mmx config show
 mmx config set --key region --value cn
+mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
 mmx config export-schema | jq .
 ```
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -403,3 +403,26 @@ mmx config show
 export MINIMAX_API_KEY=sk-xxxxx
 export MINIMAX_REGION=cn
 ```
+
+### Default Model Configuration
+
+Set per-modality defaults so you don't need `--model` every time:
+
+```bash
+# Set defaults
+mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
+mmx config set --key default-speech-model --value speech-2.8-hd
+mmx config set --key default-video-model --value MiniMax-Hailuo-2.3
+mmx config set --key default-music-model --value music-2.6
+
+# Use without --model
+mmx text chat --message "Hello"
+mmx speech synthesize --text "Hello" --out hello.mp3
+mmx video generate --prompt "Ocean waves"
+mmx music generate --prompt "Upbeat pop" --instrumental
+
+# --model still overrides per-call
+mmx text chat --model MiniMax-M2.7 --message "Hello"
+```
+
+**Resolution priority**: `--model` flag > config default > hardcoded fallback.


### PR DESCRIPTION
## Summary

Document the new per-modality default model configuration feature in the skill guide, README, and README_CN.

## What Changed

- **skill/SKILL.md**: Added "Default Model Configuration" section with usage examples
- **README.md**: Added `default-text-model` example to config section
- **README_CN.md**: Same update for Chinese readers

## Usage

```bash
# Set defaults
mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
mmx config set --key default-speech-model --value speech-2.8-hd
mmx config set --key default-video-model --value MiniMax-Hailuo-2.3
mmx config set --key default-music-model --value music-2.6

# Use without --model
mmx text chat --message "Hello"
mmx speech synthesize --text "Hello" --out hello.mp3
mmx video generate --prompt "Ocean waves"
mmx music generate --prompt "Upbeat pop" --instrumental

# --model still overrides per-call
mmx text chat --model MiniMax-M2.7 --message "Hello"
```

**Resolution priority**: `--model` flag > config default > hardcoded fallback.

## Related

Paired with PR #89 (source code + tests for the feature).