### PR TITLE
fix(quota): correct column order in --quiet output (#91)

### DIFF
--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -37,8 +37,12 @@ export default defineCommand({
 
     if (config.quiet) {
       for (const m of models) {
-        const remaining = m.current_interval_total_count - m.current_interval_usage_count;
-        console.log(`${m.model_name}\t${m.current_interval_usage_count}\t${m.current_interval_total_count}\t${remaining}`);
+        // NOTE: current_interval_usage_count from the API actually contains the REMAINING value, not usage.
+        // We rename it here for clarity and compute the actual used amount.
+        const remaining = m.current_interval_usage_count;
+        const total = m.current_interval_total_count;
+        const used = Math.max(0, total - remaining);
+        console.log(`${m.model_name}\t${used}\t${total}\t${remaining}`);
       }
       return;
     }


### PR DESCRIPTION
## Fix: quota --quiet column order

The API field `current_interval_usage_count` actually contains the **remaining** quota, not the usage count. This caused confusing output in `--quiet` mode where columns were labeled `name | remaining | total | used`.

### Changes
- Renamed variable for clarity (the misleading name was causing confusion)
- Reordered output to: `name | used | total | remaining`

### Note
The table display (`mmx quota show`) already computed `used = total - remaining` correctly. The bug was only in `--quiet` mode.

**Fixes:** #91

---
*Submitted via mmx-cli contributor workflow*