### PR TITLE
fix(auth): replace exec() with execFile/spawn to prevent shell injection (#79)

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -44,13 +44,21 @@ export async function startBrowserFlow(
 
   const authUrl = `${config.authorizationUrl}?${params}`;
 
-  // Open browser
-  const { exec } = await import('child_process');
+  // Open browser using execFile/spawn instead of exec to prevent shell injection.
+  // exec() passes the string to a shell, so a crafted authUrl containing shell
+  // metacharacters (e.g. from a malicious authorization server redirect) could
+  // execute arbitrary commands. execFile/spawn bypass the shell entirely. (#79)
+  const { execFile, spawn } = await import('child_process');
   const platform = process.platform;
-  const openCmd = platform === 'darwin' ? 'open' :
-    platform === 'win32' ? 'start' : 'xdg-open';
 
-  exec(`${openCmd} "${authUrl}"`);
+  if (platform === 'darwin') {
+    execFile('open', [authUrl]);
+  } else if (platform === 'win32') {
+    // On Windows, 'start' is a shell built-in — use cmd.exe /c start explicitly.
+    spawn('cmd.exe', ['/c', 'start', '', authUrl], { shell: false, detached: true });
+  } else {
+    execFile('xdg-open', [authUrl]);
+  }
   process.stderr.write('Opening browser to authenticate with MiniMax...\n');
 
   // Start local server to receive callback


### PR DESCRIPTION
## Summary

Fixes the shell injection vulnerability in `src/auth/oauth.ts` reported in #79.

## Root cause

`exec()` passes its argument to the system shell (`/bin/sh` on Unix, `cmd.exe` on Windows). The OAuth authorization URL was passed directly to `exec()`:

```typescript
exec(`${openCmd} "${authUrl}"`);
```

A crafted `authUrl` containing shell metacharacters (e.g. from a malicious or tampered authorization server) could execute arbitrary commands on the user's machine. Example attack vector:

```
https://evil.com/auth?redirect_uri=..."; rm -rf ~/; echo "
```

## Fix

Replace `exec()` with `execFile()` / `spawn()`, which **bypass the shell entirely** and pass arguments as an array:

| Platform | Before | After |
|---|---|---|
| macOS | `exec('open "' + url + '"')` | `execFile('open', [url])` |
| Linux | `exec('xdg-open "' + url + '"')` | `execFile('xdg-open', [url])` |
| Windows | `exec('start "' + url + '"')` | `spawn('cmd.exe', ['/c', 'start', '', url], { shell: false })` |

Windows requires `cmd.exe` because `start` is a shell built-in, but the URL is passed as a separate argument — never interpolated into a shell string.

## Part of #79

This PR addresses the **Critical #1** item (shell injection). The other items (#2–#6) require larger changes (keychain integration, file locking, etc.) and are best addressed in separate PRs.
