### PR TITLE
docs: expand README quickstarts, auth, and scripting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,61 @@ npm install -g mmx-cli
 ## Quick Start
 
 ```bash
-# Authenticate
+# Authenticate with a persistent API key
 mmx auth login --api-key sk-xxxxx
 
 # Start creating
 mmx text chat --message "What is MiniMax?"
 mmx image "A cat in a spacesuit"
 mmx speech synthesize --text "Hello!" --out hello.mp3
-mmx video generate --prompt "Ocean waves at sunset"
-mmx music generate --prompt "Upbeat pop" --lyrics "[verse] La da dee, sunny day"
+mmx video generate --prompt "Ocean waves at sunset" --download sunset.mp4
+mmx music generate --prompt "Upbeat pop" --lyrics "[Verse] La da dee, sunny day" --out song.mp3
 mmx search "MiniMax AI latest news"
 mmx vision photo.jpg
 mmx quota
+```
+
+Resources with a single subcommand auto-forward, so `mmx image ...` is equivalent to `mmx image generate ...`, and `mmx quota` is equivalent to `mmx quota show`.
+
+## Command Quickstart Matrix
+
+| Goal | Shortcut | Explicit form | Typical stdout |
+| --- | --- | --- | --- |
+| Chat with a model | `mmx text --message "What is MiniMax?"` | `mmx text chat --message "What is MiniMax?"` | Assistant text |
+| Generate images | `mmx image "A cat in a spacesuit"` | `mmx image generate --prompt "A cat in a spacesuit"` | Saved file path(s) or JSON metadata |
+| Generate a video and save it | `mmx video --prompt "Ocean waves" --download sunset.mp4` | `mmx video generate --prompt "Ocean waves" --download sunset.mp4` | Saved file info or path |
+| Start an async video job | `mmx video --prompt "Ocean waves" --async` | `mmx video generate --prompt "Ocean waves" --async` | `{"taskId":"..."}` |
+| Synthesize speech | `mmx speech synthesize --text "Hello!" --out hello.mp3` | Same | Saved file info or path |
+| Generate music | `mmx music generate --prompt "Upbeat pop" --lyrics-file song.txt --out song.mp3` | Same | Saved file info or path |
+| Describe an image | `mmx vision photo.jpg` | `mmx vision describe --image photo.jpg` | Description text |
+| Search the web | `mmx search "MiniMax AI"` | `mmx search query --q "MiniMax AI"` | Search results or JSON |
+| Inspect auth or quota | `mmx auth status` / `mmx quota` | `mmx auth status` / `mmx quota show` | Human-readable status table or JSON |
+
+## Authentication Modes
+
+| Mode | Best for | How to use it | Stored in |
+| --- | --- | --- | --- |
+| One-off API key override | CI, scripts, temporary testing | Add `--api-key sk-...` to any command | Not persisted |
+| Persistent API key login | Local shells, agent workstations | `mmx auth login --api-key sk-...` | `~/.mmx/config.json` |
+| OAuth browser login | Interactive user sessions | `mmx auth login` | `~/.mmx/credentials.json` |
+| OAuth device-code login | SSH, headless terminals | `mmx auth login --no-browser` | `~/.mmx/credentials.json` |
+| Environment bootstrap | CI or first-run setup | `export MINIMAX_API_KEY=sk-...` | Environment only unless you save it |
+
+Request-time credential resolution is:
+
+1. `--api-key`
+2. `~/.mmx/credentials.json` (OAuth)
+3. `api_key` in `~/.mmx/config.json`
+
+Useful auth commands:
+
+```bash
+mmx auth login --api-key sk-xxxxx   # validate + save api_key to ~/.mmx/config.json
+mmx auth login                      # browser-based OAuth flow
+mmx auth login --no-browser         # device-code OAuth flow
+mmx auth status --output json
+mmx auth refresh
+mmx auth logout
 ```
 
 ## Commands
@@ -65,7 +108,7 @@ mmx quota
 
 ```bash
 mmx text chat --message "Write a poem"
-mmx text chat --model MiniMax-M2.7-highspeed --message "Hello" --stream
+mmx text --message "Hello" --model MiniMax-M2.7-highspeed
 mmx text chat --system "You are a coding assistant" --message "Fizzbuzz in Go"
 mmx text chat --message "user:Hi" --message "assistant:Hey!" --message "How are you?"
 cat messages.json | mmx text chat --messages-file - --output json
@@ -76,7 +119,7 @@ cat messages.json | mmx text chat --messages-file - --output json
 ```bash
 mmx image "A cat in a spacesuit"
 mmx image generate --prompt "A cat" --n 3 --aspect-ratio 16:9
-mmx image generate --prompt "Logo" --out-dir ./out/
+mmx image generate --prompt "Logo" --out-dir ./out --out-prefix brand
 ```
 
 ### `mmx video`
@@ -95,19 +138,19 @@ mmx speech synthesize --text "Hello!" --out hello.mp3
 mmx speech synthesize --text "Stream me" --stream | mpv -
 mmx speech synthesize --text "Hi" --voice English_magnetic_voiced_man --speed 1.2
 echo "Breaking news" | mmx speech synthesize --text-file - --out news.mp3
-mmx speech voices
+mmx speech voices --output json
 ```
 
 ### `mmx music`
 
 ```bash
 # Generate with lyrics
-mmx music generate --prompt "Upbeat pop" --lyrics "[verse] La da dee, sunny day" --out song.mp3
+mmx music generate --prompt "Upbeat pop" --lyrics "[Verse] La da dee, sunny day" --out song.mp3
 # Auto-generate lyrics from prompt
 mmx music generate --prompt "Indie folk, melancholic, rainy night" --lyrics-optimizer --out song.mp3
 # Instrumental (no vocals)
 mmx music generate --prompt "Cinematic orchestral" --instrumental --out bgm.mp3
-# Cover — generate a cover version from a reference audio file
+# Cover generation from a reference audio file
 mmx music cover --prompt "Jazz, piano, warm female vocal" --audio-file original.mp3 --out cover.mp3
 mmx music cover --prompt "Indie folk" --audio https://example.com/song.mp3 --out cover.mp3
 ```
@@ -127,31 +170,87 @@ mmx search "MiniMax AI"
 mmx search query --q "latest news" --output json
 ```
 
-### `mmx auth`
-
-```bash
-mmx auth login --api-key sk-xxxxx
-mmx auth login                    # OAuth browser flow
-mmx auth status
-mmx auth refresh
-mmx auth logout
-```
-
-### `mmx config` · `mmx quota`
+### `mmx config` · `mmx quota` · `mmx update`
 
 ```bash
 mmx quota
+mmx quota --output json
 mmx config show
 mmx config set --key region --value cn
-mmx config export-schema | jq .
+mmx config export-schema --command "video generate" | jq .
+mmx update
 ```
 
-### `mmx update`
+## JSON Output and Scripting
+
+Every command supports the global `--output json` flag. For shell automation, combine it with `jq`, `--quiet`, and `--non-interactive`.
 
 ```bash
-mmx update
-mmx update latest
+# Inspect the active auth source
+mmx auth status --output json | jq .
+
+# Parse remaining quota by model
+mmx quota --output json \
+  | jq '.model_remains[] | {model: .model_name, remaining: (.current_interval_total_count - .current_interval_usage_count)}'
+
+# Feed a saved conversation into text chat
+cat conversation.json | mmx text chat --messages-file - --output json
+
+# Export one command as an agent tool schema
+mmx config export-schema --command "video generate" > video-generate.tool.json
+
+# Use quiet mode when you only need the returned path or URL
+mmx image "Paper-cut fox" --quiet
+mmx music generate --prompt "Lo-fi beat" --instrumental --output-format url --quiet
 ```
+
+## Shell Workflows for Agents
+
+```bash
+# 1) Upload a file, capture the file_id, then reuse it in a follow-up command
+FILE_ID=$(mmx file upload --file spec.pdf --quiet)
+mmx vision describe --file-id "$FILE_ID" --prompt "Summarize the architecture diagram"
+```
+
+```bash
+# 2) Kick off a long-running video job, poll it later, then download explicitly
+TASK_ID=$(mmx video generate --prompt "A robot painting" --async | jq -r '.taskId')
+FILE_ID=$(mmx video task get --task-id "$TASK_ID" --output json | jq -r '.file_id')
+mmx video download --file-id "$FILE_ID" --out ./artifacts/robot.mp4
+```
+
+```bash
+# 3) Keep agent runs deterministic and pipe-friendly
+mmx text chat \
+  --message "Return exactly three deployment risks as JSON." \
+  --output json \
+  --non-interactive
+```
+
+```bash
+# 4) Turn generated text into speech in one shell flow
+mmx text chat --message "Write a 20-word greeting for new users." --quiet \
+  | mmx speech synthesize --text-file - --out welcome.mp3
+```
+
+## Download Paths and Generated File Names
+
+| Command | Default output location | How to make it explicit |
+| --- | --- | --- |
+| `mmx image` | Current working directory as `image_001.jpg`, `image_002.jpg`, ... | Use `--out-dir` and optionally `--out-prefix` |
+| `mmx speech synthesize` | Current working directory as `speech_<timestamp>.<format>` | Use `--out ./path/file.mp3` |
+| `mmx music generate` | Current working directory as `music_<timestamp>.<format>` | Use `--out ./path/file.mp3` |
+| `mmx music cover` | Current working directory as `cover_<timestamp>.<format>` | Use `--out ./path/file.mp3` |
+| `mmx video generate --download` | Exactly the path you pass to `--download` | Prefer this for reproducible workflows |
+| `mmx video generate` without `--download` | Auto-downloads to a temp directory and prints the local path | Add `--download` if you need a stable location |
+| `mmx video generate --async` | No file is downloaded yet; stdout is only the task id JSON | Later call `mmx video task get` / `mmx video download` |
+
+Troubleshooting tips:
+
+- Relative paths are resolved from your current shell working directory.
+- If a file seems to disappear after `mmx video generate`, you probably ran without `--download`; the printed path points to the temp copy.
+- `--quiet` is useful for scripting because it prints the path, URL, or file id without extra tables.
+- If you need predictable artifact names in CI, always pass `--out`, `--download`, or `--out-dir` + `--out-prefix`.
 
 ## Thanks to
 

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -8,6 +8,13 @@ All commands follow `resource + verb`:
 mmx <resource> <verb> [flags]
 ```
 
+When a resource has only one subcommand, the CLI auto-forwards:
+
+```bash
+mmx image "A cat in a spacesuit"      # same as: mmx image generate --prompt "A cat in a spacesuit"
+mmx quota                             # same as: mmx quota show
+```
+
 ## Command Tree
 
 ```
@@ -18,47 +25,67 @@ mmx
 │   ├── refresh            Manually refresh OAuth token
 │   └── logout             Revoke tokens and clear stored credentials
 ├── text
-│   └── chat               Send a chat completion (M2.7 / M2.7-highspeed)
+│   └── chat               Send a chat completion (MiniMax Messages API)
 ├── speech
-│   └── synthesize         Synchronous TTS, ≤10k chars
+│   ├── synthesize         Synchronous TTS, <=10k chars
+│   └── voices             List available voices
 ├── image
-│   └── generate           Generate images (image-01)
+│   └── generate           Generate images
 ├── video
 │   ├── generate           Create a video generation task
 │   ├── task
 │   │   └── get            Query video task status
 │   └── download           Download a completed video by file ID
 ├── music
-│   └── generate           Generate a song (music-2.5)
+│   ├── generate           Generate a song
+│   └── cover              Generate a cover version from reference audio
+├── file
+│   ├── upload             Upload a file to MiniMax storage
+│   ├── list               List uploaded files
+│   └── delete             Delete an uploaded file
+├── search
+│   └── query              Search the web
+├── vision
+│   └── describe           Describe an image by path, URL, or file ID
 ├── quota
 │   └── show               Display Token Plan usage and remaining quotas
-└── config
-    ├── show               Display current configuration
-    └── set                Set a config value
+├── config
+│   ├── show               Display current configuration
+│   ├── set                Set a config value
+│   └── export-schema      Export command schemas for agent tooling
+├── update                 Show how to update the CLI
+└── help                   Print command help and API reference links
 ```
 
 ## Exit Codes
 
-| Code | Meaning                          |
-|------|----------------------------------|
-| 0    | Success                          |
-| 1    | General / server error           |
-| 2    | Usage error (bad flags)          |
-| 3    | Authentication error             |
-| 4    | Rate limit or quota exceeded     |
-| 5    | Timeout                          |
-| 10   | Content sensitivity filter       |
+| Code | Meaning |
+|------|---------|
+| 0    | Success |
+| 1    | General / server error |
+| 2    | Usage error (bad flags) |
+| 3    | Authentication error |
+| 4    | Rate limit or quota exceeded |
+| 5    | Timeout |
+| 10   | Content sensitivity filter |
 
 ## Authentication
 
-Credential resolution order:
+Persistent auth storage:
+
+- `~/.mmx/config.json` stores `api_key`, region, base URL, output format, and timeout
+- `~/.mmx/credentials.json` stores OAuth access and refresh tokens
+
+Request-time credential resolution order:
+
 1. `--api-key` flag
-2. `$MINIMAX_API_KEY` env var
-3. `~/.mmx/credentials.json` (OAuth)
-4. `api_key` in `~/.mmx/config.yaml`
+2. `~/.mmx/credentials.json` (OAuth)
+3. `api_key` in `~/.mmx/config.json`
+
+`$MINIMAX_API_KEY` is used as a bootstrap input during auth setup and can be persisted into `config.json`.
 
 ## Configuration
 
 Config precedence: flag > env var > config file > default.
 
-Config file: `~/.mmx/config.yaml`
+Config file: `~/.mmx/config.json`


### PR DESCRIPTION
## Summary
- add a command quickstart matrix and clarify the shortcut vs explicit command forms in README
- document auth modes, credential storage locations, JSON output patterns, and shell workflows for agent usage
- add troubleshooting for download paths and generated file names
- sync `docs/cli-design.md` with the current command tree and `config.json` / `credentials.json` behavior

## Testing
- `git diff --check`
- `npm test` *(fails locally: `bun` is not installed in this environment)*