### PR TITLE
fix: use correct token_plan/remains endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
   "engines": {

--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -41,7 +41,7 @@ export function vlmEndpoint(baseUrl: string): string {
 export function quotaEndpoint(baseUrl: string): string {
   // Quota endpoint uses api subdomain
   const host = baseUrl.includes('minimaxi.com') ? 'https://api.minimaxi.com' : 'https://api.minimax.io';
-  return `${host}/v1/api/openplatform/coding_plan/remains`;
+  return `${host}/v1/token_plan/remains`;
 }
 
 export function fileUploadEndpoint(baseUrl: string): string {

--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -114,13 +114,11 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
   for (const m of models) {
     console.log(boxLine(W, '├', '─', '┤', useColor));
 
-    const remaining = m.current_interval_usage_count;
+    const used = m.current_interval_usage_count;
     const limit = m.current_interval_total_count;
-    const used = Math.max(0, limit - remaining);
     const usedPct = limit > 0 ? Math.round((used / limit) * 100) : 0;
-    const weekRemaining = m.current_weekly_usage_count;
+    const weekUsed = m.current_weekly_usage_count;
     const weekLimit = m.current_weekly_total_count;
-    const weekUsed = Math.max(0, weekLimit - weekRemaining);
     const resets = formatDuration(m.remains_time, L.now);
 
     const nameStr = m.model_name.padEnd(maxNameLen);

--- a/test/fixtures/quota-response.json
+++ b/test/fixtures/quota-response.json
@@ -3,53 +3,45 @@
     "status_code": 0,
     "status_msg": "success"
   },
-  "data": {
-    "plan": "Max-Highspeed",
-    "period_start": "2025-08-01",
-    "period_end": "2025-09-01",
-    "models": [
-      {
-        "model": "MiniMax-M2.7-highspeed",
-        "used": 8241,
-        "limit": 15000,
-        "reset": "rolling 5h",
-        "unit": "requests"
-      },
-      {
-        "model": "speech-2.8-hd",
-        "used": 4300,
-        "limit": 19000,
-        "reset": "daily",
-        "unit": "characters"
-      },
-      {
-        "model": "image-01",
-        "used": 42,
-        "limit": 200,
-        "reset": "daily",
-        "unit": "images"
-      },
-      {
-        "model": "Hailuo-2.3",
-        "used": 1,
-        "limit": 3,
-        "reset": "daily",
-        "unit": "videos"
-      },
-      {
-        "model": "Hailuo-2.3-Fast",
-        "used": 0,
-        "limit": 3,
-        "reset": "daily",
-        "unit": "videos"
-      },
-      {
-        "model": "music-2.5",
-        "used": 2,
-        "limit": 7,
-        "reset": "daily",
-        "unit": "songs"
-      }
-    ]
-  }
+  "model_remains": [
+    {
+      "model_name": "MiniMax-M*",
+      "start_time": 1776355200000,
+      "end_time": 1776373200000,
+      "remains_time": 7151954,
+      "current_interval_total_count": 1500,
+      "current_interval_usage_count": 228,
+      "current_weekly_total_count": 0,
+      "current_weekly_usage_count": 0,
+      "weekly_start_time": 1776009600000,
+      "weekly_end_time": 1776614400000,
+      "weekly_remains_time": 248351954
+    },
+    {
+      "model_name": "speech-hd",
+      "start_time": 1776355200000,
+      "end_time": 1776441600000,
+      "remains_time": 75551954,
+      "current_interval_total_count": 9000,
+      "current_interval_usage_count": 0,
+      "current_weekly_total_count": 63000,
+      "current_weekly_usage_count": 0,
+      "weekly_start_time": 1776009600000,
+      "weekly_end_time": 1776614400000,
+      "weekly_remains_time": 248351954
+    },
+    {
+      "model_name": "image-01",
+      "start_time": 1776355200000,
+      "end_time": 1776441600000,
+      "remains_time": 75551954,
+      "current_interval_total_count": 100,
+      "current_interval_usage_count": 0,
+      "current_weekly_total_count": 700,
+      "current_weekly_usage_count": 0,
+      "weekly_start_time": 1776009600000,
+      "weekly_end_time": 1776614400000,
+      "weekly_remains_time": 248351954
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Switch quota endpoint from `v1/api/openplatform/coding_plan/remains` to `v1/token_plan/remains`
- Fix usage calculation: `current_interval_usage_count` is used count, not remaining
- Update test fixture to match real API response format
- Bump version to 1.0.8

## Test plan
- [x] `mmx quota show` returns correct data from new endpoint
- [x] `curl` verified both `minimaxi.com` and `minimax.io` domains work
- [x] Usage/remaining values match actual API response