### PR TITLE
fix(image): add --out flag for saving to exact file path

### DIFF
--- a/src/commands/image/generate.ts
+++ b/src/commands/image/generate.ts
@@ -9,7 +9,7 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { ImageRequest, ImageResponse } from '../../types/api';
 import { mkdirSync, existsSync, readFileSync } from 'fs';
-import { join, resolve, extname } from 'path';
+import { dirname, join, resolve, extname } from 'path';
 
 const MIME_TYPES: Record<string, string> = {
   '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
@@ -33,6 +33,7 @@ export default defineCommand({
     { flag: '--prompt-optimizer', description: 'Automatically optimize the prompt before generation for better results.' },
     { flag: '--aigc-watermark', description: 'Embed AI-generated content watermark in the output image.' },
     { flag: '--subject-ref <params>', description: 'Subject reference for character consistency. Format: type=character,image=path-or-url' },
+    { flag: '--out <path>', description: 'Save image to exact file path (single image only)' },
     { flag: '--out-dir <dir>', description: 'Download images to directory' },
     { flag: '--out-prefix <prefix>', description: 'Filename prefix (default: image)' },
   ],
@@ -46,6 +47,8 @@ export default defineCommand({
     'mmx image generate --prompt "Wide landscape" --width 1920 --height 1080',
     '# Optimized prompt with watermark',
     'mmx image generate --prompt "sunset" --prompt-optimizer --aigc-watermark',
+    '# Save to exact path',
+    'mmx image generate --prompt "A cat" --out /tmp/cat.jpg',
   ],
   async run(config: Config, flags: GlobalFlags) {
     let prompt = (flags.prompt ?? (flags._positional as string[]|undefined)?.[0]) as string | undefined;
@@ -86,6 +89,11 @@ export default defineCommand({
       };
       validateSize('width', width);
       validateSize('height', height);
+    }
+
+    const outPath = flags.out as string | undefined;
+    if (outPath && (flags.n as number) > 1) {
+      throw new CLIError('--out cannot be used with --n > 1. Use --out-dir instead.', ExitCode.USAGE);
     }
 
     const body: ImageRequest = {
@@ -149,23 +157,31 @@ export default defineCommand({
       process.stderr.write('[Model: image-01]\n');
     }
 
-    const outDir = (flags.outDir as string | undefined) ?? '.';
-    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
-
-    const prefix = (flags.outPrefix as string) || 'image';
     const saved: string[] = [];
 
-    for (let i = 0; i < imageUrls.length; i++) {
-      const filename = `${prefix}_${String(i + 1).padStart(3, '0')}.jpg`;
-      const destPath = join(outDir, filename);
-
-      // Warn if overwriting existing file (but don't block)
+    if (outPath) {
+      const dir = dirname(resolve(outPath));
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      const destPath = resolve(outPath);
       if (existsSync(destPath)) {
         process.stderr.write(`Warning: overwriting existing file: ${destPath}\n`);
       }
-
-      await downloadFile(imageUrls[i]!, destPath, { quiet: config.quiet });
+      await downloadFile(imageUrls[0]!, destPath, { quiet: config.quiet });
       saved.push(destPath);
+    } else {
+      const outDir = (flags.outDir as string | undefined) ?? '.';
+      if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+      const prefix = (flags.outPrefix as string) || 'image';
+
+      for (let i = 0; i < imageUrls.length; i++) {
+        const filename = `${prefix}_${String(i + 1).padStart(3, '0')}.jpg`;
+        const destPath = join(outDir, filename);
+        if (existsSync(destPath)) {
+          process.stderr.write(`Warning: overwriting existing file: ${destPath}\n`);
+        }
+        await downloadFile(imageUrls[i]!, destPath, { quiet: config.quiet });
+        saved.push(destPath);
+      }
     }
 
     // --output json is respected even in --quiet mode (JSON is the actual output, not progress)


### PR DESCRIPTION
## Summary
- Add `--out <path>` flag to `image generate` for saving to an exact file path
- Validates that `--out` cannot be used with `--n > 1` (use `--out-dir` instead)
- Auto-creates parent directories if they don't exist
- Consistent with `speech synthesize --out` behavior

## Test
```bash
# Save to exact path
mmx image generate --prompt "A cat" --out /tmp/cat.jpg
# saved: /tmp/cat.jpg

# Error when used with multiple images
mmx image generate --prompt "A cat" --n 3 --out /tmp/cat.jpg
# error: --out cannot be used with --n > 1. Use --out-dir instead.
```

Closes #112