### PR TITLE
chore: bump version to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump version from 1.0.11 to 1.0.12

## Changes since 1.0.11
- fix: force HTTPS for image downloads and add base64 response format (#94/#113)
- fix: add `--out` flag for image generate (#112/#114)
- docs: add missing image generate flags to SKILL.md