### PR TITLE
fix: reject invalid numeric flags

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -131,7 +131,11 @@ export function parseFlags(argv: string[], options: OptionDef[]): GlobalFlags {
         if (arr) arr.push(value);
         else (flags as Record<string, unknown>)[camelKey] = [value];
       } else if (schema.numbers.has(camelKey)) {
-        (flags as Record<string, unknown>)[camelKey] = Number(value);
+        const numericValue = Number(value);
+        if (value.trim() === '' || !Number.isFinite(numericValue)) {
+          throw new Error(`Flag --${key} requires a numeric value, got "${value}".`);
+        }
+        (flags as Record<string, unknown>)[camelKey] = numericValue;
       } else {
         (flags as Record<string, unknown>)[camelKey] = value;
       }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { parseFlags } from '../src/args';
+import type { OptionDef } from '../src/command';
+
+const OPTIONS: OptionDef[] = [
+  { flag: '--timeout <seconds>', description: 'Request timeout', type: 'number' },
+  { flag: '--message <text>', description: 'Message text', type: 'array' },
+];
+
+describe('parseFlags', () => {
+  it('rejects non-numeric values for number flags', () => {
+    expect(() => parseFlags(['--timeout', 'abc'], OPTIONS)).toThrow(
+      'Flag --timeout requires a numeric value, got "abc".',
+    );
+  });
+
+  it('rejects empty values for number flags', () => {
+    expect(() => parseFlags(['--timeout='], OPTIONS)).toThrow(
+      'Flag --timeout requires a numeric value, got "".',
+    );
+  });
+
+  it('still accepts finite numeric values', () => {
+    const flags = parseFlags(['--timeout', '1.5'], OPTIONS);
+
+    expect(flags.timeout).toBe(1.5);
+  });
+});


### PR DESCRIPTION
## Summary
- validate number-typed flags during parseFlags
- reject empty, NaN, and infinite numeric inputs before commands build requests
- add parser coverage for invalid and valid number values

## Root cause
Number flags were parsed with Number(value) and stored without validation. Invalid input such as --max-tokens abc became NaN, which could later serialize as null in request JSON or fail deeper in timeout handling.

## Validation
- bun test test/args.test.ts
- bun run typecheck
- bunx eslint src/args.ts test/args.test.ts
- bun test

Note: full repository lint still has pre-existing failures in unrelated tests: test/auth/timeout-fix.test.ts and test/client/stream.test.ts.