### PR TITLE
release: v1.0.13 — audio format validation & lint cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
   "engines": {

--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -8,7 +8,7 @@ import { detectOutputFormat, formatOutput } from '../../output/formatter';
 import { saveAudioOutput } from '../../output/audio';
 import { writeFileSync } from 'fs';
 import { readTextFromPathOrStdin } from '../../utils/fs';
-import { T2A_FORMATS, formatList, validateAudioFormat, validateT2AStreaming } from '../../utils/audio-formats';
+import { T2A_FORMATS, formatList, validateAudioFormat, validateT2AStreaming, t2aDefaultSampleRate } from '../../utils/audio-formats';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { SpeechRequest, SpeechResponse } from '../../types/api';
@@ -81,7 +81,7 @@ export default defineCommand({
       },
       audio_setting: {
         format: (flags.format as string) || 'mp3',
-        sample_rate: (flags.sampleRate as number) ?? 32000,
+        sample_rate: (flags.sampleRate as number) ?? t2aDefaultSampleRate(ext, 32000),
         bitrate: (flags.bitrate as number) ?? 128000,
         channel: (flags.channels as number) ?? 1,
       },

--- a/src/utils/audio-formats.ts
+++ b/src/utils/audio-formats.ts
@@ -20,6 +20,16 @@ export function validateAudioFormat(format: string, formats: readonly string[]):
   }
 }
 
+const T2A_SAMPLE_RATE: Partial<Record<T2AFormat, number>> = {
+  opus: 24000,
+  pcmu_raw: 8000,
+  pcmu_wav: 8000,
+};
+
+export function t2aDefaultSampleRate(format: string, fallback: number): number {
+  return T2A_SAMPLE_RATE[format as T2AFormat] ?? fallback;
+}
+
 export function validateT2AStreaming(format: string, stream: boolean): void {
   if (stream && format === 'wav') {
     throw new CLIError(

--- a/src/utils/audio-formats.ts
+++ b/src/utils/audio-formats.ts
@@ -2,7 +2,7 @@ import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 
 export const T2A_FORMATS = ['mp3', 'pcm', 'flac', 'wav', 'pcmu_raw', 'pcmu_wav', 'opus'] as const;
-export const MUSIC_FORMATS = ['mp3', 'wav', 'pcm', 'flac'] as const;
+export const MUSIC_FORMATS = ['mp3', 'wav', 'pcm'] as const;
 
 export type T2AFormat = (typeof T2A_FORMATS)[number];
 export type MusicFormat = (typeof MUSIC_FORMATS)[number];

--- a/test/commands/music/generate.test.ts
+++ b/test/commands/music/generate.test.ts
@@ -190,7 +190,7 @@ describe('music generate command', () => {
     ).rejects.toThrow('Invalid audio format "opus"');
   });
 
-  it.each(['mp3', 'wav', 'pcm', 'flac'])(
+  it.each(['mp3', 'wav', 'pcm'])(
     'accepts %s format in dry-run',
     async (fmt) => {
       const origLog = console.log;

--- a/test/commands/speech/synthesize.test.ts
+++ b/test/commands/speech/synthesize.test.ts
@@ -259,4 +259,43 @@ describe('speech synthesize format validation', () => {
       synthesizeCommand.execute(config, { ...flags, format: 'wav', stream: true }),
     ).rejects.toThrow('wav format is not supported in streaming');
   });
+
+  it('defaults opus sample rate to 24000', async () => {
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+    try {
+      await synthesizeCommand.execute(config, { ...flags, format: 'opus' });
+      const parsed = JSON.parse(output);
+      expect(parsed.request.audio_setting.sample_rate).toBe(24000);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('defaults pcmu_wav sample rate to 8000', async () => {
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+    try {
+      await synthesizeCommand.execute(config, { ...flags, format: 'pcmu_wav' });
+      const parsed = JSON.parse(output);
+      expect(parsed.request.audio_setting.sample_rate).toBe(8000);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('respects explicit --sample-rate even for opus', async () => {
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+    try {
+      await synthesizeCommand.execute(config, { ...flags, format: 'opus', sampleRate: 16000 });
+      const parsed = JSON.parse(output);
+      expect(parsed.request.audio_setting.sample_rate).toBe(16000);
+    } finally {
+      console.log = originalLog;
+    }
+  });
 });

--- a/test/utils/audio-formats.test.ts
+++ b/test/utils/audio-formats.test.ts
@@ -5,6 +5,7 @@ import {
   formatList,
   validateAudioFormat,
   validateT2AStreaming,
+  t2aDefaultSampleRate,
 } from '../../src/utils/audio-formats';
 
 describe('audio-formats', () => {
@@ -50,6 +51,24 @@ describe('audio-formats', () => {
   describe('formatList', () => {
     it('joins formats with comma-space', () => {
       expect(formatList(['a', 'b', 'c'])).toBe('a, b, c');
+    });
+  });
+
+  describe('t2aDefaultSampleRate', () => {
+    it('returns 24000 for opus', () => {
+      expect(t2aDefaultSampleRate('opus', 32000)).toBe(24000);
+    });
+
+    it('returns 8000 for pcmu_raw', () => {
+      expect(t2aDefaultSampleRate('pcmu_raw', 32000)).toBe(8000);
+    });
+
+    it('returns 8000 for pcmu_wav', () => {
+      expect(t2aDefaultSampleRate('pcmu_wav', 32000)).toBe(8000);
+    });
+
+    it('returns fallback for mp3', () => {
+      expect(t2aDefaultSampleRate('mp3', 32000)).toBe(32000);
     });
   });
 });

--- a/test/utils/audio-formats.test.ts
+++ b/test/utils/audio-formats.test.ts
@@ -22,12 +22,12 @@ describe('audio-formats', () => {
   });
 
   describe('MUSIC_FORMATS', () => {
-    it.each(['mp3', 'wav', 'pcm', 'flac'] as const)(
+    it.each(['mp3', 'wav', 'pcm'] as const)(
       'accepts %s',
       (fmt) => expect(() => validateAudioFormat(fmt, MUSIC_FORMATS)).not.toThrow(),
     );
 
-    it.each(['opus', 'pcmu_raw', 'pcmu_wav', 'aac'])(
+    it.each(['opus', 'pcmu_raw', 'pcmu_wav', 'flac', 'aac'])(
       'rejects %s',
       (fmt) => expect(() => validateAudioFormat(fmt, MUSIC_FORMATS)).toThrow(/Invalid audio format/),
     );


### PR DESCRIPTION
## Summary

- Centralized audio format validation with per-API domain format sets
  - **T2A**: `mp3, pcm, flac, wav, pcmu_raw, pcmu_wav, opus`
  - **Music**: `mp3, wav, pcm`
- Auto-select compatible sample rate per format (opus → 24kHz, pcmu_* → 8kHz)
- Enforce `wav` non-streaming constraint for T2A
- Dynamic help text generated from format lists
- Fix all pre-existing lint errors across test files
- Bump version to 1.0.13

Supersedes #116

## Verified by real API calls

| Command | Result |
|---------|--------|
| `speech synthesize` mp3/opus/pcmu_raw/pcmu_wav/stream/subtitles | All pass |
| `speech` invalid format / wav+stream | Correctly rejected |
| `music generate` mp3/wav/pcm | All pass |
| `music generate` flac/opus | Correctly rejected |
| `image generate` | Pass |
| `video generate` | Pass |
| `text chat` | Pass |
| `search query` | Pass |
| `quota show` / `auth status` / `config` | Pass |
| `bun test` 191 pass, 0 fail | `bun run lint` 0 errors |

## Test plan

- [x] 191 unit tests pass
- [x] Lint clean
- [x] Build produces 133KB CLI + 115KB SDK
- [x] All commands verified with real API calls