### PR TITLE
fix: preserve search shorthand with aliases

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -91,6 +91,18 @@ class CommandRegistry {
       }
     }
 
+    // Alias-only group: auto-forward when every child points to the same command.
+    // Example: `mmx search "query"` should work even when both `search query`
+    // and `search web` are registered as aliases for the same implementation.
+    if (matched.length > 0 && node.children.size > 1) {
+      const children = Array.from(node.children.values());
+      const commands = children.map((child) => child.command);
+      const first = commands[0];
+      if (first && commands.every((command) => command === first)) {
+        return { command: first, extra: commandPath.slice(matched.length) };
+      }
+    }
+
     // If we matched some path but no command, show help for that group
     if (matched.length > 0 && node.children.size > 0) {
       const subcommands = Array.from(node.children.entries())

--- a/test/commands/aliases.test.ts
+++ b/test/commands/aliases.test.ts
@@ -8,6 +8,13 @@ describe('command aliases', () => {
     expect(web.command).toBe(query.command);
   });
 
+  it('auto-forwards search shorthand when child commands are aliases', () => {
+    const shorthand = registry.resolve(['search', 'MiniMax AI latest news']);
+    const query = registry.resolve(['search', 'query']);
+    expect(shorthand.command).toBe(query.command);
+    expect(shorthand.extra).toEqual(['MiniMax AI latest news']);
+  });
+
   it('resolves "speech generate" same as "speech synthesize"', () => {
     const generate = registry.resolve(['speech', 'generate']);
     const synthesize = registry.resolve(['speech', 'synthesize']);


### PR DESCRIPTION
## Summary

Fixes #136.

This restores the documented resource-level search shorthand:

```bash
mmx search "MiniMax AI latest news"
```

when a command group contains multiple child names that are aliases for the same command implementation.

## Root Cause

The registry only auto-forwarded a resource group when it had exactly one child command. Adding `search web` as an alias for `search query` made the `search` group have two children, so `mmx search <query>` started resolving as an unknown command even though both children point to the same command.

## Changes

- Keep the existing single-child auto-forward behavior.
- Add alias-only group forwarding when every child command points to the same command object.
- Add a regression test for `mmx search "MiniMax AI latest news"` style resolution.

## Validation

- `bun test test/commands/aliases.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run dev search "MiniMax AI latest news" --dry-run --output json`
