### PR TITLE
feat(auth): add OAuth device-code login (Global / CN) into config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ npm install -g mmx-cli
 ## Quick Start
 
 ```bash
-# Authenticate
+# Authenticate (interactive — choose MiniMax OAuth or paste an API key)
+mmx auth login
+
+# Or non-interactive
 mmx auth login --api-key sk-xxxxx
 
 # Start creating
@@ -130,16 +133,21 @@ mmx search query --q "latest news" --output json
 ### `mmx auth`
 
 ```bash
-mmx auth login --api-key sk-xxxxx
-mmx auth login                    # OAuth browser flow
+mmx auth login                              # interactive: pick OAuth (Global / China) or paste an API key
+mmx auth login --api-key sk-xxxxx           # save an API key directly
+mmx auth login --recommend                  # skip the menu, pick OAuth region interactively
+mmx auth login --recommend --region=global  # OAuth → api.minimax.io
+mmx auth login --recommend --region=cn      # OAuth → api.minimaxi.com
 mmx auth status
 mmx auth refresh
 mmx auth logout
 ```
 
 `mmx auth status` is the canonical way to verify active authentication.
-`~/.mmx/credentials.json` exists only for OAuth login. API-key login persists to
-`~/.mmx/config.json` (and `--api-key` can also be passed per command).
+Both OAuth and API-key credentials live in `~/.mmx/config.json` (the two are
+mutually exclusive — logging in with one method clears the other). API keys
+can also be passed per command via `--api-key`. With an API key, the region
+is auto-detected by probing both Global and CN.
 
 ### `mmx config` · `mmx quota`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,7 +45,10 @@ npm install -g mmx-cli
 ## 快速开始
 
 ```bash
-# 认证
+# 认证（交互式 — 选 MiniMax OAuth 或粘 API Key）
+mmx auth login
+
+# 或者非交互
 mmx auth login --api-key sk-xxxxx
 
 # 开始创作
@@ -130,16 +133,20 @@ mmx search query --q "最新动态" --output json
 ### `mmx auth`
 
 ```bash
-mmx auth login --api-key sk-xxxxx
-mmx auth login                    # OAuth 浏览器授权
+mmx auth login                              # 交互式：选 OAuth (Global / 中国) 或粘 API Key
+mmx auth login --api-key sk-xxxxx           # 直接保存 API Key
+mmx auth login --recommend                  # 跳过 3 选 1 菜单，弹出 region 选择器
+mmx auth login --recommend --region=global  # 直接 OAuth → api.minimax.io
+mmx auth login --recommend --region=cn      # 直接 OAuth → api.minimaxi.com
 mmx auth status
 mmx auth refresh
 mmx auth logout
 ```
 
-请使用 `mmx auth status` 作为认证状态的权威检查方式。`~/.mmx/credentials.json`
-只在 OAuth 登录时存在；API Key 登录会写入 `~/.mmx/config.json`（也可每次通过
-`--api-key` 直接传入）。
+请使用 `mmx auth status` 作为认证状态的权威检查方式。OAuth 与 API Key 凭据
+都保存在 `~/.mmx/config.json` 里，**两者互斥** —— 用一种登录会清掉另一种。
+也可以每次通过 `--api-key` 直接传入。使用 API Key 登录时，会自动同时探测
+Global 与中国两个 region，选用能通过的那个。
 
 ### `mmx config` · `mmx quota`
 

--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -1,51 +1,26 @@
-import { readFileSync, writeFileSync, renameSync, unlinkSync, existsSync, statSync } from 'fs';
-import { getCredentialsPath, ensureConfigDir } from '../config/paths';
+import { readConfigFile, writeConfigFile } from '../config/loader';
 import type { CredentialFile } from './types';
 
-export async function loadCredentials(): Promise<CredentialFile | null> {
-  const path = getCredentialsPath();
-  if (!existsSync(path)) return null;
+/**
+ * OAuth credentials live inside the user's main config file
+ * (`~/.mmx/config.json`) under the `oauth` subobject. This keeps a
+ * single source of truth for all CLI state.
+ */
 
-  try {
-    checkPermissions(path);
-    const raw = readFileSync(path, 'utf-8');
-    const data = JSON.parse(raw) as CredentialFile;
-    if (!data.access_token || !data.refresh_token) return null;
-    return data;
-  } catch (err) {
-    const e = err as Error;
-    if (e instanceof SyntaxError || e.message.includes('JSON')) {
-      process.stderr.write(`Warning: credentials file is corrupted. Run 'mmx auth logout' to reset.\n`);
-    }
-    return null;
-  }
+export async function loadCredentials(): Promise<CredentialFile | null> {
+  const cfg = readConfigFile();
+  return cfg.oauth ?? null;
 }
 
 export async function saveCredentials(creds: CredentialFile): Promise<void> {
-  await ensureConfigDir();
-  const path = getCredentialsPath();
-  const tmp = path + '.tmp';
-  writeFileSync(tmp, JSON.stringify(creds, null, 2) + '\n', { mode: 0o600 });
-  renameSync(tmp, path);
+  const existing = readConfigFile() as Record<string, unknown>;
+  existing.oauth = creds;
+  await writeConfigFile(existing);
 }
 
 export async function clearCredentials(): Promise<void> {
-  const path = getCredentialsPath();
-  if (existsSync(path)) {
-    unlinkSync(path);
-  }
-}
-
-function checkPermissions(path: string): void {
-  try {
-    const stat = statSync(path);
-    const mode = stat.mode & 0o777;
-    if (mode !== 0o600) {
-      process.stderr.write(
-        `Warning: ${path} has permissions ${mode.toString(8)}, expected 600.\n`,
-      );
-    }
-  } catch {
-    // Ignore permission check errors on platforms that don't support it
-  }
+  const existing = readConfigFile() as Record<string, unknown>;
+  if (!('oauth' in existing)) return;
+  delete existing.oauth;
+  await writeConfigFile(existing);
 }

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,207 +1,134 @@
-import type { OAuthTokens } from './types';
+import type { OAuthCredentials, Region } from '../config/schema';
+import { OAUTH_HOSTS } from '../config/schema';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 
-// OAuth configuration — exact endpoints TBD pending MiniMax OAuth docs
-export interface OAuthConfig {
-  clientId: string;
-  authorizationUrl: string;
-  tokenUrl: string;
-  deviceCodeUrl: string;
-  scopes: string[];
-  callbackPort: number;
+const CLIENT_ID = '659cf4c1-615c-45f6-a5f6-4bf15eb476e5';
+const CLIENT_NAME = 'MiniMax CLI';
+const SCOPES = ['openid', 'profile', 'coding_plan'];
+
+interface DeviceCodeResponse {
+  base_resp?: { status_code: number; status_msg?: string };
+  user_code: string;
+  verification_uri: string;
+  expired_in: number;   // absolute Unix ms (server's name; unfortunate)
+  interval: number;     // poll interval in ms
+  state: string;
 }
 
-const DEFAULT_OAUTH_CONFIG: OAuthConfig = {
-  clientId: 'mmx-cli',
-  authorizationUrl: 'https://platform.minimax.io/oauth/authorize',
-  tokenUrl: 'https://api.minimax.io/v1/oauth/token',
-  deviceCodeUrl: 'https://api.minimax.io/v1/oauth/device/code',
-  scopes: ['api'],
-  callbackPort: 18991,
-};
+interface TokenResponse {
+  base_resp?: { status_code: number; status_msg?: string };
+  status: 'pending' | 'success' | string;
+  access_token?: string;
+  refresh_token?: string;
+  expired_in?: number;  // absolute Unix ms
+  resource_url?: string;
+}
 
-export async function startBrowserFlow(
-  config: OAuthConfig = DEFAULT_OAUTH_CONFIG,
-): Promise<OAuthTokens> {
+/**
+ * Run the OAuth 2.0 Device Authorization Grant against the MiniMax
+ * account server for the given region (RFC 8628 + PKCE).
+ *
+ * Opens the user's browser to the verification URL, displays the
+ * user code, and polls /oauth2/token until the user approves.
+ */
+export async function deviceCodeLogin(region: Region): Promise<OAuthCredentials> {
+  const host = OAUTH_HOSTS[region];
+
   const { randomBytes, createHash } = await import('crypto');
   const codeVerifier = randomBytes(32).toString('base64url');
-  const codeChallenge = createHash('sha256')
-    .update(codeVerifier)
-    .digest('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const state = randomBytes(16).toString('base64url');
 
-  const state = randomBytes(16).toString('hex');
-
-  const params = new URLSearchParams({
-    client_id: config.clientId,
-    response_type: 'code',
-    redirect_uri: `http://localhost:${config.callbackPort}/callback`,
-    scope: config.scopes.join(' '),
-    state,
-    code_challenge: codeChallenge,
-    code_challenge_method: 'S256',
-  });
-
-  const authUrl = `${config.authorizationUrl}?${params}`;
-
-  // Open browser using execFile/spawn instead of exec to prevent shell injection.
-  // exec() passes the string to a shell, so a crafted authUrl containing shell
-  // metacharacters (e.g. from a malicious authorization server redirect) could
-  // execute arbitrary commands. execFile/spawn bypass the shell entirely. (#79)
-  const { execFile, spawn } = await import('child_process');
-  const platform = process.platform;
-
-  if (platform === 'darwin') {
-    execFile('open', [authUrl]);
-  } else if (platform === 'win32') {
-    // On Windows, 'start' is a shell built-in — use cmd.exe /c start explicitly.
-    spawn('cmd.exe', ['/c', 'start', '', authUrl], { shell: false, detached: true });
-  } else {
-    execFile('xdg-open', [authUrl]);
-  }
-  process.stderr.write('Opening browser to authenticate with MiniMax...\n');
-
-  // Start local server to receive callback
-  const code = await waitForCallback(config.callbackPort, state);
-
-  // Exchange code for tokens
-  const tokenRes = await fetch(config.tokenUrl, {
+  const codeRes = await fetch(`${host}/oauth2/device/code`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
-      grant_type: 'authorization_code',
-      code,
-      client_id: config.clientId,
-      redirect_uri: `http://localhost:${config.callbackPort}/callback`,
-      code_verifier: codeVerifier,
-    }),
-  });
-
-  if (!tokenRes.ok) {
-    const body = await tokenRes.text();
-    throw new CLIError(
-      `OAuth token exchange failed: ${body}`,
-      ExitCode.AUTH,
-    );
-  }
-
-  return (await tokenRes.json()) as OAuthTokens;
-}
-
-async function waitForCallback(port: number, expectedState: string): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      server.stop();
-      reject(new CLIError('OAuth callback timed out.', ExitCode.TIMEOUT));
-    }, 120_000);
-
-    const server = Bun.serve({
-      port,
-      fetch(req) {
-        const url = new URL(req.url);
-        if (url.pathname !== '/callback') {
-          return new Response('Not found', { status: 404 });
-        }
-
-        const code = url.searchParams.get('code');
-        const state = url.searchParams.get('state');
-        const error = url.searchParams.get('error');
-
-        if (error) {
-          clearTimeout(timeout);
-          server.stop();
-          reject(new CLIError(`OAuth error: ${error}`, ExitCode.AUTH));
-          return new Response(
-            '<html><body><h1>Authentication Failed</h1><p>You can close this tab.</p></body></html>',
-            { headers: { 'Content-Type': 'text/html' } },
-          );
-        }
-
-        if (!code || state !== expectedState) {
-          clearTimeout(timeout);
-          server.stop();
-          reject(new CLIError('Invalid OAuth callback.', ExitCode.AUTH));
-          return new Response('Invalid callback', { status: 400 });
-        }
-
-        clearTimeout(timeout);
-        server.stop();
-        resolve(code);
-        return new Response(
-          '<html><body><h1>Authentication Successful</h1><p>You can close this tab.</p></body></html>',
-          { headers: { 'Content-Type': 'text/html' } },
-        );
-      },
-    });
-  });
-}
-
-export async function startDeviceCodeFlow(
-  config: OAuthConfig = DEFAULT_OAUTH_CONFIG,
-): Promise<OAuthTokens> {
-  // Request device code
-  const codeRes = await fetch(config.deviceCodeUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: config.clientId,
-      scope: config.scopes.join(' '),
+      client_id: CLIENT_ID,
+      scope: SCOPES.join(' '),
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      state,
     }),
   });
 
   if (!codeRes.ok) {
+    const body = await codeRes.text().catch(() => '');
     throw new CLIError(
-      'Failed to start device code flow.',
+      `Failed to start device-code flow (HTTP ${codeRes.status}).`,
       ExitCode.AUTH,
+      body || `URL: ${host}/oauth2/device/code`,
     );
   }
 
-  const { device_code, user_code, verification_uri, interval, expires_in } =
-    (await codeRes.json()) as {
-      device_code: string;
-      user_code: string;
-      verification_uri: string;
-      interval: number;
-      expires_in: number;
-    };
+  const data = (await codeRes.json()) as DeviceCodeResponse;
+  if (data.state !== state) {
+    throw new CLIError('OAuth state mismatch.', ExitCode.AUTH);
+  }
 
-  process.stderr.write(`\nVisit: ${verification_uri}\n`);
-  process.stderr.write(`Enter code: ${user_code}\n`);
+  openBrowser(data.verification_uri);
+  process.stderr.write(`\nOpened: ${data.verification_uri}\n`);
+  process.stderr.write(`Code:   ${data.user_code}\n`);
+  process.stderr.write(`Client: ${CLIENT_NAME}\n`);
   process.stderr.write('Waiting for authorization...\n');
 
-  // Poll for authorization
-  const deadline = Date.now() + expires_in * 1000;
-  const pollInterval = (interval || 5) * 1000;
+  const deadline = data.expired_in;
+  const intervalMs = data.interval || 3000;
 
   while (Date.now() < deadline) {
-    await new Promise(r => setTimeout(r, pollInterval));
+    await sleep(intervalMs);
 
-    const tokenRes = await fetch(config.tokenUrl, {
+    const tokRes = await fetch(`${host}/oauth2/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-        device_code,
-        client_id: config.clientId,
+        client_id: CLIENT_ID,
+        user_code: data.user_code,
+        code_verifier: codeVerifier,
       }),
     });
 
-    if (tokenRes.ok) {
-      return (await tokenRes.json()) as OAuthTokens;
+    if (!tokRes.ok) {
+      throw new CLIError(
+        `Device-code authorization failed (HTTP ${tokRes.status}).`,
+        ExitCode.AUTH,
+      );
     }
 
-    const err = (await tokenRes.json()) as { error: string };
-    if (err.error === 'authorization_pending') continue;
-    if (err.error === 'slow_down') {
-      await new Promise(r => setTimeout(r, 5000));
-      continue;
+    const tok = (await tokRes.json()) as TokenResponse;
+    if (tok.status === 'pending') continue;
+    if (tok.status === 'success' && tok.access_token) {
+      return {
+        access_token: tok.access_token,
+        refresh_token: tok.refresh_token ?? '',
+        expires_at: new Date(tok.expired_in ?? Date.now()).toISOString(),
+        region,
+        resource_url: tok.resource_url,
+      };
     }
-
-    throw new CLIError(
-      `Device code authorization failed: ${err.error}`,
-      ExitCode.AUTH,
-    );
+    throw new CLIError(`Device-code authorization failed: ${tok.status}`, ExitCode.AUTH);
   }
 
-  throw new CLIError('Device code authorization timed out.', ExitCode.TIMEOUT);
+  throw new CLIError('Device-code authorization timed out.', ExitCode.TIMEOUT);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+/**
+ * Open `url` in the user's default browser without going through a shell.
+ * Using execFile/spawn (not exec) avoids shell-injection via crafted URLs (#79).
+ */
+function openBrowser(url: string): void {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { execFile, spawn } = require('child_process') as typeof import('child_process');
+  if (process.platform === 'darwin') {
+    execFile('open', [url]);
+  } else if (process.platform === 'win32') {
+    spawn('cmd.exe', ['/c', 'start', '', url], { shell: false, detached: true });
+  } else {
+    execFile('xdg-open', [url]);
+  }
 }

--- a/src/auth/refresh.ts
+++ b/src/auth/refresh.ts
@@ -1,94 +1,114 @@
-import type { OAuthTokens, CredentialFile } from "./types";
-import { saveCredentials } from "./credentials";
-import { CLIError } from "../errors/base";
-import { ExitCode } from "../errors/codes";
+import type { CredentialFile } from './types';
+import type { Region } from '../config/schema';
+import { OAUTH_HOSTS } from '../config/schema';
+import { saveCredentials } from './credentials';
+import { CLIError } from '../errors/base';
+import { ExitCode } from '../errors/codes';
 
-// OAuth config — endpoints TBD pending MiniMax OAuth documentation
-const TOKEN_URL = "https://api.minimax.io/v1/oauth/token";
-
-const MAX_REFRESH_RETRIES = 2;
+const CLIENT_ID = '659cf4c1-615c-45f6-a5f6-4bf15eb476e5';
+const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 500;
+const REQUEST_TIMEOUT_MS = 10_000;
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
+interface RefreshResponse {
+  base_resp?: { status_code: number; status_msg?: string };
+  status: string;
+  access_token?: string;
+  refresh_token?: string;
+  expired_in?: number;  // absolute Unix ms
+  resource_url?: string;
+}
+
+/**
+ * POST /oauth2/token with grant_type=refresh_token. Retries 5xx /
+ * network errors up to MAX_RETRIES times; gives up immediately on 4xx.
+ */
 export async function refreshAccessToken(
   refreshToken: string,
-): Promise<OAuthTokens> {
+  region: Region = 'global',
+): Promise<{ access_token: string; refresh_token: string; expires_at: string; resource_url?: string }> {
+  const tokenUrl = `${OAUTH_HOSTS[region]}/oauth2/token`;
   let lastErr: Error | null = null;
 
-  for (let attempt = 0; attempt <= MAX_REFRESH_RETRIES; attempt++) {
-    if (attempt > 0) {
-      // Exponential backoff before retry
-      await new Promise(r => setTimeout(r, RETRY_DELAY_MS * attempt));
-    }
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) await new Promise(r => setTimeout(r, RETRY_DELAY_MS * attempt));
 
     let res: Response;
     try {
-      res = await fetch(TOKEN_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      res = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
-          grant_type: "refresh_token",
+          grant_type: 'refresh_token',
           refresh_token: refreshToken,
+          client_id: CLIENT_ID,
         }),
-        signal: AbortSignal.timeout(10_000),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
     } catch (err) {
-      const isTimeout =
-        err instanceof Error &&
-        (err.name === "AbortError" ||
-          err.name === "TimeoutError" ||
-          err.message.includes("timed out"));
+      const isTimeout = err instanceof Error
+        && (err.name === 'AbortError' || err.name === 'TimeoutError' || err.message.includes('timed out'));
       lastErr = new Error(
         isTimeout
-          ? "Token refresh timed out — auth server did not respond within 10 s."
+          ? 'Token refresh timed out — auth server did not respond within 10 s.'
           : `Token refresh failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      continue; // retry
+      continue;
     }
 
     if (!res.ok) {
-      // 4xx errors won't recover with retry
       if (res.status >= 400 && res.status < 500) {
         throw new CLIError(
-          "OAuth session expired and could not be refreshed.",
+          'OAuth session expired and could not be refreshed.',
           ExitCode.AUTH,
-          "Re-authenticate: mmx auth login",
+          'Re-authenticate: mmx auth login',
         );
       }
       lastErr = new Error(`Token refresh failed: HTTP ${res.status}`);
-      continue; // retry 5xx errors
+      continue;
     }
 
-    const data = (await res.json()) as OAuthTokens;
-    return data;
+    const body = (await res.json()) as RefreshResponse;
+    if (body.status !== 'success' || !body.access_token) {
+      throw new CLIError(
+        `OAuth refresh failed: ${body.status}.`,
+        ExitCode.AUTH,
+        'Re-authenticate: mmx auth login',
+      );
+    }
+    return {
+      access_token: body.access_token,
+      refresh_token: body.refresh_token ?? refreshToken,
+      expires_at: new Date(body.expired_in ?? Date.now()).toISOString(),
+      resource_url: body.resource_url,
+    };
   }
 
-  // All retries exhausted
   throw new CLIError(
-    `Token refresh failed after ${MAX_REFRESH_RETRIES + 1} attempts: ${lastErr?.message}`,
+    `Token refresh failed after ${MAX_RETRIES + 1} attempts: ${lastErr?.message}`,
     ExitCode.AUTH,
-    "Check your network connection.\nRe-authenticate: mmx auth login",
+    'Check your network connection.\nRe-authenticate: mmx auth login',
   );
 }
 
+/**
+ * Returns a valid access token for the given credentials, refreshing
+ * (and persisting) the stored token if it expires within 5 minutes.
+ */
 export async function ensureFreshToken(creds: CredentialFile): Promise<string> {
   const expiresAt = new Date(creds.expires_at).getTime();
-  const bufferMs = 5 * 60 * 1000; // 5 minutes
+  if (Date.now() < expiresAt - REFRESH_BUFFER_MS) return creds.access_token;
 
-  if (Date.now() < expiresAt - bufferMs) {
-    return creds.access_token;
-  }
-
-  // Token expired or about to expire — refresh
-  const tokens = await refreshAccessToken(creds.refresh_token);
-
+  const fresh = await refreshAccessToken(creds.refresh_token, creds.region ?? 'global');
   const updated: CredentialFile = {
-    access_token: tokens.access_token,
-    refresh_token: tokens.refresh_token,
-    expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
-    token_type: "Bearer",
+    access_token: fresh.access_token,
+    refresh_token: fresh.refresh_token,
+    expires_at: fresh.expires_at,
+    region: creds.region,
+    resource_url: fresh.resource_url ?? creds.resource_url,
     account: creds.account,
   };
-
   await saveCredentials(updated);
   return updated.access_token;
 }

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -11,11 +11,11 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
     return { token: config.apiKey, method: 'api-key', source: 'flag' };
   }
 
-  // 2. OAuth credentials file
+  // 2. OAuth credentials in config file
   const oauth = await loadCredentials();
   if (oauth) {
     const token = await ensureFreshToken(oauth);
-    return { token, method: 'oauth', source: 'credentials.json' };
+    return { token, method: 'oauth', source: 'config.json' };
   }
 
   // 3. API key from config file

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -11,13 +11,12 @@ import { saveCredentials, loadCredentials } from './credentials';
 interface AuthChoice {
   value: 'oauth-global' | 'oauth-cn' | 'api-key';
   label: string;
-  hint: string;
 }
 
 const AUTH_CHOICES: AuthChoice[] = [
-  { value: 'oauth-global', label: 'MiniMax',   hint: 'OAuth login (Global)' },
-  { value: 'oauth-cn',     label: 'MiniMaxCN', hint: 'OAuth login (China)' },
-  { value: 'api-key',      label: 'API key',   hint: 'Paste sk-cp-... or sk-...' },
+  { value: 'oauth-global', label: 'MiniMax (OAuth login, Global)' },
+  { value: 'oauth-cn',     label: 'MiniMax (OAuth login, China)' },
+  { value: 'api-key',      label: 'API key' },
 ];
 
 export async function ensureAuth(config: Config): Promise<void> {
@@ -61,7 +60,7 @@ export async function pickAuthMethod(): Promise<AuthChoice['value']> {
   const { select, isCancel } = await import('@clack/prompts');
   const value = await select({
     message: 'How would you like to authenticate?',
-    options: AUTH_CHOICES.map(c => ({ value: c.value, label: `${c.label}  ·  ${c.hint}` })),
+    options: AUTH_CHOICES.map(c => ({ value: c.value, label: c.label })),
   });
   if (isCancel(value)) throw new CLIError('Authentication cancelled.', ExitCode.AUTH);
   return value as AuthChoice['value'];

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -1,45 +1,85 @@
-import type { Config } from '../config/schema';
+import type { Config, Region } from '../config/schema';
 import { readConfigFile, writeConfigFile } from '../config/loader';
 import { promptText, promptConfirm } from '../utils/prompt';
 import { isInteractive } from '../utils/env';
 import { maskToken } from '../utils/token';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
+import { deviceCodeLogin } from './oauth';
+import { saveCredentials, loadCredentials } from './credentials';
 
-export async function ensureApiKey(config: Config): Promise<void> {
+interface AuthChoice {
+  value: 'oauth-global' | 'oauth-cn' | 'api-key';
+  label: string;
+  hint: string;
+}
+
+const AUTH_CHOICES: AuthChoice[] = [
+  { value: 'oauth-global', label: 'MiniMax',   hint: 'OAuth login (Global)' },
+  { value: 'oauth-cn',     label: 'MiniMaxCN', hint: 'OAuth login (China)' },
+  { value: 'api-key',      label: 'API key',   hint: 'Paste sk-cp-... or sk-...' },
+];
+
+export async function ensureAuth(config: Config): Promise<void> {
   if (config.apiKey || config.fileApiKey) return;
+  if (await loadCredentials()) return;
 
   const envKey = process.env.MINIMAX_API_KEY;
-  let key: string | undefined;
-
   if (envKey) {
     if (!isInteractive({ nonInteractive: config.nonInteractive })) {
-      key = envKey;
-    } else {
-      const use = await promptConfirm({
-        message: `Found MINIMAX_API_KEY in environment (${maskToken(envKey)}). Save it to config file?`,
-      });
-      if (use) key = envKey;
+      return; // env key is enough; no prompt
     }
+    const save = await promptConfirm({
+      message: `Found MINIMAX_API_KEY in environment (${maskToken(envKey)}). Save to config file?`,
+    });
+    if (save) {
+      await persistApiKey(config, envKey);
+    }
+    return;
   }
 
-  if (!key) {
-    if (!isInteractive({ nonInteractive: config.nonInteractive })) {
-      throw new CLIError(
-        'No API key found.',
-        ExitCode.AUTH,
-        'Set env var:    export MINIMAX_API_KEY=sk-xxxxx\nPass directly:  --api-key sk-xxxxx',
-      );
-    }
+  if (!isInteractive({ nonInteractive: config.nonInteractive })) {
+    throw new CLIError(
+      'No credentials found.',
+      ExitCode.AUTH,
+      'Log in:        mmx auth login\nPass directly:  --api-key sk-xxxxx',
+    );
+  }
+
+  const choice = await pickAuthMethod();
+  if (choice === 'api-key') {
     const input = await promptText({ message: 'Enter your MiniMax API key:' });
     if (!input) throw new CLIError('API key is required.', ExitCode.AUTH);
-    key = input;
+    await persistApiKey(config, input);
+    return;
   }
 
+  await runOAuthLogin(choice === 'oauth-cn' ? 'cn' : 'global');
+}
+
+export async function pickAuthMethod(): Promise<AuthChoice['value']> {
+  const { select, isCancel } = await import('@clack/prompts');
+  const value = await select({
+    message: 'How would you like to authenticate?',
+    options: AUTH_CHOICES.map(c => ({ value: c.value, label: `${c.label}  ·  ${c.hint}` })),
+  });
+  if (isCancel(value)) throw new CLIError('Authentication cancelled.', ExitCode.AUTH);
+  return value as AuthChoice['value'];
+}
+
+export async function runOAuthLogin(region: Region): Promise<void> {
+  const creds = await deviceCodeLogin(region);
+  await saveCredentials(creds);
+  process.stderr.write('Logged in successfully.\n');
+  process.stderr.write('Credentials saved to ~/.mmx/config.json\n');
+}
+
+async function persistApiKey(config: Config, key: string): Promise<void> {
   const data = { ...(readConfigFile() as Record<string, unknown>), api_key: key };
   await writeConfigFile(data);
   config.fileApiKey = key;
-
-  const path = config.configPath ?? '~/.mmx/config.json';
-  process.stderr.write(`API key saved to ${path}\n`);
+  process.stderr.write(`API key saved to ${config.configPath ?? '~/.mmx/config.json'}\n`);
 }
+
+// Legacy alias kept so main.ts keeps working without churn.
+export const ensureApiKey = ensureAuth;

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -1,4 +1,5 @@
 import type { Config, Region } from '../config/schema';
+import { REGIONS } from '../config/schema';
 import { readConfigFile, writeConfigFile } from '../config/loader';
 import { promptText, promptConfirm } from '../utils/prompt';
 import { isInteractive } from '../utils/env';
@@ -6,7 +7,7 @@ import { maskToken } from '../utils/token';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 import { deviceCodeLogin } from './oauth';
-import { saveCredentials, loadCredentials } from './credentials';
+import { loadCredentials } from './credentials';
 
 interface AuthChoice {
   value: 'oauth-global' | 'oauth-cn' | 'api-key';
@@ -14,10 +15,14 @@ interface AuthChoice {
 }
 
 const AUTH_CHOICES: AuthChoice[] = [
-  { value: 'oauth-global', label: 'MiniMax (OAuth login, Global)' },
-  { value: 'oauth-cn',     label: 'MiniMax (OAuth login, China)' },
+  { value: 'oauth-global', label: `MiniMax (OAuth login → ${stripScheme(REGIONS.global)})` },
+  { value: 'oauth-cn',     label: `MiniMax (OAuth login → ${stripScheme(REGIONS.cn)})` },
   { value: 'api-key',      label: 'API key' },
 ];
+
+function stripScheme(url: string): string {
+  return url.replace(/^https?:\/\//, '');
+}
 
 export async function ensureAuth(config: Config): Promise<void> {
   if (config.apiKey || config.fileApiKey) return;
@@ -66,9 +71,31 @@ export async function pickAuthMethod(): Promise<AuthChoice['value']> {
   return value as AuthChoice['value'];
 }
 
+/**
+ * Region-only picker used by `mmx auth login --recommend` (no API-key option).
+ */
+export async function pickOAuthRegion(): Promise<Region> {
+  const { select, isCancel } = await import('@clack/prompts');
+  const value = await select({
+    message: 'Select an OAuth region:',
+    options: [
+      { value: 'global', label: `Global  →  ${stripScheme(REGIONS.global)}` },
+      { value: 'cn',     label: `China   →  ${stripScheme(REGIONS.cn)}` },
+    ],
+  });
+  if (isCancel(value)) throw new CLIError('Authentication cancelled.', ExitCode.AUTH);
+  return value as Region;
+}
+
 export async function runOAuthLogin(region: Region): Promise<void> {
   const creds = await deviceCodeLogin(region);
-  await saveCredentials(creds);
+  // OAuth and api_key are mutually exclusive — drop any stale api_key
+  // so `mmx auth status` and the resolver see a single source of truth.
+  const existing = readConfigFile() as Record<string, unknown>;
+  delete existing.api_key;
+  existing.oauth = creds;
+  existing.region = region;
+  await writeConfigFile(existing);
   process.stderr.write('Logged in successfully.\n');
   process.stderr.write('Credentials saved to ~/.mmx/config.json\n');
 }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,19 +1,6 @@
 export type AuthMethod = 'api-key' | 'oauth';
 
-export interface OAuthTokens {
-  access_token: string;
-  refresh_token: string;
-  expires_in: number;
-  token_type: 'Bearer';
-}
-
-export interface CredentialFile {
-  access_token: string;
-  refresh_token: string;
-  expires_at: string; // ISO 8601
-  token_type: 'Bearer';
-  account?: string;
-}
+export type { OAuthCredentials as CredentialFile } from '../config/schema';
 
 export interface ResolvedCredential {
   token: string;

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -11,6 +11,7 @@ import { readConfigFile, writeConfigFile } from '../../config/loader';
 import { isInteractive } from '../../utils/env';
 import { maskToken } from '../../utils/token';
 import type { Config, Region } from '../../config/schema';
+import { REGIONS } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { QuotaResponse, QuotaModelRemain } from '../../types/api';
 
@@ -26,6 +27,17 @@ async function showQuotaAfterLogin(config: Config): Promise<void> {
   } catch {
     // Non-fatal — login succeeded, quota display is best-effort
   }
+}
+
+/**
+ * Mirrors the `mmx` (no-args) dashboard: prints the help panel
+ * followed by the quota snapshot. Used right after a successful
+ * login so the user lands somewhere useful instead of an empty prompt.
+ */
+async function showDashboardAfterLogin(config: Config): Promise<void> {
+  const { registry } = await import('../../registry');
+  registry.printHelp([], process.stderr, config.region);
+  await showQuotaAfterLogin(config);
 }
 
 export default defineCommand({
@@ -92,9 +104,14 @@ export default defineCommand({
     const region: Region = (flags.region as Region) || (choice === 'oauth-cn' ? 'cn' : 'global');
     await runOAuthLogin(region);
 
-    // Best-effort quota snapshot — derive an effective baseUrl from the OAuth region.
-    const cfg: Config = { ...config, region, baseUrl: config.baseUrl };
-    await showQuotaAfterLogin(cfg);
+    // Reload config so the OAuth subobject (and its resource_url) are picked up.
+    const fresh = readConfigFile();
+    const cfg: Config = {
+      ...config,
+      region,
+      baseUrl: fresh.oauth?.resource_url || REGIONS[region],
+    };
+    await showDashboardAfterLogin(cfg);
   },
 });
 
@@ -122,5 +139,5 @@ async function loginWithApiKey(config: Config, key: string): Promise<void> {
   await writeConfigFile(existing);
   process.stderr.write(`API key saved to ${getConfigPath()}\n`);
 
-  await showQuotaAfterLogin({ ...config, apiKey: key });
+  await showDashboardAfterLogin({ ...config, apiKey: key });
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,10 +1,11 @@
 import { defineCommand } from '../../command';
 import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
-import { pickAuthMethod, runOAuthLogin } from '../../auth/setup';
+import { pickAuthMethod, pickOAuthRegion, runOAuthLogin } from '../../auth/setup';
 import { requestJson } from '../../client/http';
 import { quotaEndpoint } from '../../client/endpoints';
 import { renderQuotaTable } from '../../output/quota-table';
+import { detectRegion } from '../../config/detect-region';
 
 import { getConfigPath } from '../../config/paths';
 import { readConfigFile, writeConfigFile } from '../../config/loader';
@@ -13,7 +14,7 @@ import { maskToken } from '../../utils/token';
 import type { Config, Region } from '../../config/schema';
 import { REGIONS } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { QuotaResponse, QuotaModelRemain } from '../../types/api';
+import type { QuotaModelRemain } from '../../types/api';
 
 interface QuotaApiResponse {
   model_remains: QuotaModelRemain[];
@@ -43,14 +44,17 @@ async function showDashboardAfterLogin(config: Config): Promise<void> {
 export default defineCommand({
   name: 'auth login',
   description: 'Authenticate via OAuth or API key',
-  usage: 'mmx auth login [--api-key <key>] [--region global|cn]',
+  usage: 'mmx auth login [--api-key <key>] [--recommend] [--region=global|cn]',
   options: [
     { flag: '--api-key <key>', description: 'Skip the menu and save this API key directly' },
+    { flag: '--recommend',     description: 'Skip the menu, go straight to OAuth (combine with --region= to skip the region picker)' },
   ],
   examples: [
     'mmx auth login',
     'mmx auth login --api-key sk-cp-xxxxx',
-    'mmx auth login --region cn',
+    'mmx auth login --recommend',
+    'mmx auth login --recommend --region=global',
+    'mmx auth login --recommend --region=cn',
   ],
   async run(config: Config, flags: GlobalFlags) {
     const envKey = process.env.MINIMAX_API_KEY;
@@ -89,6 +93,14 @@ export default defineCommand({
       );
     }
 
+    // --recommend: skip the 3-option menu, go straight to OAuth.
+    // With --region, skip the region picker too.
+    if (flags.recommend) {
+      const region = (flags.region as Region) || await pickOAuthRegion();
+      await completeOAuthLogin(config, region);
+      return;
+    }
+
     const choice = await pickAuthMethod();
     if (choice === 'api-key') {
       const { text, isCancel } = await import('@clack/prompts');
@@ -102,18 +114,22 @@ export default defineCommand({
     }
 
     const region: Region = (flags.region as Region) || (choice === 'oauth-cn' ? 'cn' : 'global');
-    await runOAuthLogin(region);
-
-    // Reload config so the OAuth subobject (and its resource_url) are picked up.
-    const fresh = readConfigFile();
-    const cfg: Config = {
-      ...config,
-      region,
-      baseUrl: fresh.oauth?.resource_url || REGIONS[region],
-    };
-    await showDashboardAfterLogin(cfg);
+    await completeOAuthLogin(config, region);
   },
 });
+
+async function completeOAuthLogin(config: Config, region: Region): Promise<void> {
+  await runOAuthLogin(region);
+
+  // Reload so the OAuth subobject (and any resource_url override) is picked up.
+  const fresh = readConfigFile();
+  const cfg: Config = {
+    ...config,
+    region,
+    baseUrl: fresh.oauth?.resource_url || REGIONS[region],
+  };
+  await showDashboardAfterLogin(cfg);
+}
 
 async function loginWithApiKey(config: Config, key: string): Promise<void> {
   if (config.dryRun) {
@@ -121,11 +137,15 @@ async function loginWithApiKey(config: Config, key: string): Promise<void> {
     return;
   }
 
-  process.stderr.write('Testing key... ');
+  // Probe both regions and pick the one the key actually authenticates against.
+  // This doubles as key validation — if neither region accepts it, the key is bad.
+  const detected = await detectRegion(key);
+  const cfg: Config = { ...config, region: detected, baseUrl: REGIONS[detected], apiKey: key };
+
+  // Verify the detection actually authorizes the quota endpoint (defends against
+  // detectRegion's graceful 'global' fallback when the network is unreachable).
   try {
-    const test = { ...config, apiKey: key };
-    await requestJson<QuotaResponse>(test, { url: quotaEndpoint(test.baseUrl) });
-    process.stderr.write('Valid\n');
+    await requestJson<QuotaApiResponse>(cfg, { url: quotaEndpoint(cfg.baseUrl) });
   } catch {
     throw new CLIError(
       'API key validation failed.',
@@ -134,10 +154,13 @@ async function loginWithApiKey(config: Config, key: string): Promise<void> {
     );
   }
 
+  // OAuth and api_key are mutually exclusive — drop any stale oauth block.
   const existing = readConfigFile() as Record<string, unknown>;
+  delete existing.oauth;
   existing.api_key = key;
+  existing.region = detected;
   await writeConfigFile(existing);
   process.stderr.write(`API key saved to ${getConfigPath()}\n`);
 
-  await showDashboardAfterLogin({ ...config, apiKey: key });
+  await showDashboardAfterLogin(cfg);
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,8 +1,7 @@
 import { defineCommand } from '../../command';
 import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
-import { saveCredentials } from '../../auth/credentials';
-import { startBrowserFlow, startDeviceCodeFlow } from '../../auth/oauth';
+import { pickAuthMethod, runOAuthLogin } from '../../auth/setup';
 import { requestJson } from '../../client/http';
 import { quotaEndpoint } from '../../client/endpoints';
 import { renderQuotaTable } from '../../output/quota-table';
@@ -11,9 +10,8 @@ import { getConfigPath } from '../../config/paths';
 import { readConfigFile, writeConfigFile } from '../../config/loader';
 import { isInteractive } from '../../utils/env';
 import { maskToken } from '../../utils/token';
-import type { Config } from '../../config/schema';
+import type { Config, Region } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { CredentialFile } from '../../auth/types';
 import type { QuotaResponse, QuotaModelRemain } from '../../types/api';
 
 interface QuotaApiResponse {
@@ -33,30 +31,27 @@ async function showQuotaAfterLogin(config: Config): Promise<void> {
 export default defineCommand({
   name: 'auth login',
   description: 'Authenticate via OAuth or API key',
-  usage: 'mmx auth login [--method oauth|api-key] [--api-key <key>] [--no-browser]',
+  usage: 'mmx auth login [--api-key <key>] [--region global|cn]',
   options: [
-    { flag: '--method <method>', description: 'Auth method: oauth (default), api-key' },
-    { flag: '--api-key <key>', description: 'API key to store' },
-    { flag: '--no-browser', description: 'Use device-code flow instead of browser' },
+    { flag: '--api-key <key>', description: 'Skip the menu and save this API key directly' },
   ],
   examples: [
     'mmx auth login',
-    'mmx auth login --no-browser',
-    'mmx auth login --api-key sk-xxxxx',
-    'mmx auth login --method api-key --api-key sk-xxxxx',
+    'mmx auth login --api-key sk-cp-xxxxx',
+    'mmx auth login --region cn',
   ],
   async run(config: Config, flags: GlobalFlags) {
     const envKey = process.env.MINIMAX_API_KEY;
     if (envKey && !flags.apiKey) {
-      const maskedEnvKey = maskToken(envKey);
+      const masked = maskToken(envKey);
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
-        const { confirm } = await import('@clack/prompts');
+        const { confirm, isCancel } = await import('@clack/prompts');
         const proceed = await confirm({
-          message: `Detected MINIMAX_API_KEY in environment (${maskedEnvKey}).\nYou are already authenticated via env.\nDo you still want to configure local persistent credentials?`,
+          message: `MINIMAX_API_KEY is set (${masked}). Configure persistent credentials anyway?`,
           initialValue: false,
         });
-        if (!proceed) {
-          process.stdout.write('Login skipped. Using environment variables.\n');
+        if (isCancel(proceed) || !proceed) {
+          process.stdout.write('Login skipped. Using environment variable.\n');
           process.exit(0);
         }
       } else {
@@ -64,72 +59,68 @@ export default defineCommand({
       }
     }
 
-    const method = flags.apiKey ? 'api-key' : (flags.method as string) || 'oauth';
-
-    if (method === 'api-key') {
-      const key = (flags.apiKey as string) || config.apiKey;
-      if (!key) {
-        throw new CLIError(
-          '--api-key is required when using --method api-key.',
-          ExitCode.USAGE,
-          'mmx auth login --api-key sk-xxxxx',
-        );
-      }
-
-      // Validate the key by calling quota endpoint
-      if (!config.dryRun) {
-        process.stderr.write('Testing key... ');
-        try {
-          const testConfig = { ...config, apiKey: key };
-          await requestJson<QuotaResponse>(testConfig, {
-            url: quotaEndpoint(testConfig.baseUrl),
-          });
-          process.stderr.write('Valid\n');
-        } catch {
-          throw new CLIError(
-            'API key validation failed.',
-            ExitCode.AUTH,
-            'Check that your key is valid and belongs to a Token Plan.',
-          );
-        }
-
-        // Store key in config.json
-        const existing = readConfigFile() as Record<string, unknown>;
-        existing.api_key = key;
-        await writeConfigFile(existing);
-        process.stderr.write(`API key saved to ${getConfigPath()}\n`);
-
-        await showQuotaAfterLogin({ ...config, apiKey: key });
-      } else {
-        console.log('Would validate and save API key.');
-      }
+    if (flags.apiKey) {
+      await loginWithApiKey(config, flags.apiKey as string);
       return;
     }
 
-    // OAuth flow
     if (config.dryRun) {
-      console.log('Would start OAuth login flow.');
+      console.log('Would prompt for auth method (oauth-global, oauth-cn, api-key).');
       return;
     }
 
-    let tokens;
-    if (flags.noBrowser) {
-      tokens = await startDeviceCodeFlow();
-    } else {
-      tokens = await startBrowserFlow();
+    if (!isInteractive({ nonInteractive: config.nonInteractive })) {
+      throw new CLIError(
+        '--api-key is required in non-interactive mode.',
+        ExitCode.USAGE,
+        'mmx auth login --api-key sk-xxxxx',
+      );
     }
 
-    const creds: CredentialFile = {
-      access_token: tokens.access_token,
-      refresh_token: tokens.refresh_token,
-      expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
-      token_type: 'Bearer',
-    };
+    const choice = await pickAuthMethod();
+    if (choice === 'api-key') {
+      const { text, isCancel } = await import('@clack/prompts');
+      const key = await text({
+        message: 'Paste your MiniMax API key:',
+        validate: (v) => (v && v.length > 0 ? undefined : 'API key cannot be empty.'),
+      });
+      if (isCancel(key)) throw new CLIError('Authentication cancelled.', ExitCode.AUTH);
+      await loginWithApiKey(config, key as string);
+      return;
+    }
 
-    await saveCredentials(creds);
-    process.stderr.write('Logged in successfully.\n');
-    process.stderr.write('Credentials saved to ~/.mmx/credentials.json\n');
+    const region: Region = (flags.region as Region) || (choice === 'oauth-cn' ? 'cn' : 'global');
+    await runOAuthLogin(region);
 
-    await showQuotaAfterLogin({ ...config, apiKey: creds.access_token });
+    // Best-effort quota snapshot — derive an effective baseUrl from the OAuth region.
+    const cfg: Config = { ...config, region, baseUrl: config.baseUrl };
+    await showQuotaAfterLogin(cfg);
   },
 });
+
+async function loginWithApiKey(config: Config, key: string): Promise<void> {
+  if (config.dryRun) {
+    console.log('Would validate and save API key.');
+    return;
+  }
+
+  process.stderr.write('Testing key... ');
+  try {
+    const test = { ...config, apiKey: key };
+    await requestJson<QuotaResponse>(test, { url: quotaEndpoint(test.baseUrl) });
+    process.stderr.write('Valid\n');
+  } catch {
+    throw new CLIError(
+      'API key validation failed.',
+      ExitCode.AUTH,
+      'Check that your key is valid and belongs to a Token Plan.',
+    );
+  }
+
+  const existing = readConfigFile() as Record<string, unknown>;
+  existing.api_key = key;
+  await writeConfigFile(existing);
+  process.stderr.write(`API key saved to ${getConfigPath()}\n`);
+
+  await showQuotaAfterLogin({ ...config, apiKey: key });
+}

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -22,29 +22,28 @@ export default defineCommand({
     const hasConfigKey = !!fileConfig.api_key;
 
     if (config.dryRun) {
-      if (creds) console.log('Would remove ~/.mmx/credentials.json');
+      if (creds) console.log('Would clear oauth from ~/.mmx/config.json');
       if (hasConfigKey) console.log('Would clear api_key from ~/.mmx/config.json');
       if (!creds && !hasConfigKey) console.log('No credentials to clear.');
       console.log('No changes made.');
       return;
     }
 
+    if (!creds && !hasConfigKey) {
+      process.stderr.write('No credentials to clear.\n');
+      return;
+    }
+
     if (creds) {
       await clearCredentials();
-      process.stderr.write('Removed ~/.mmx/credentials.json\n');
+      process.stderr.write('Cleared oauth from ~/.mmx/config.json\n');
     }
 
     if (hasConfigKey) {
-      try {
-        const updated = fileConfig as Record<string, unknown>;
-        delete updated.api_key;
-        await writeConfigFile(updated);
-        process.stderr.write('Cleared api_key from ~/.mmx/config.json\n');
-      } catch { /* ignore */ }
-    }
-
-    if (!creds && !hasConfigKey) {
-      process.stderr.write('No credentials to clear.\n');
+      const updated = readConfigFile() as Record<string, unknown>;
+      delete updated.api_key;
+      await writeConfigFile(updated);
+      process.stderr.write('Cleared api_key from ~/.mmx/config.json\n');
     }
   },
 });

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -31,13 +31,14 @@ export default defineCommand({
       return;
     }
 
-    const tokens = await refreshAccessToken(creds.refresh_token);
+    const fresh = await refreshAccessToken(creds.refresh_token, creds.region ?? 'global');
 
     const updated: CredentialFile = {
-      access_token: tokens.access_token,
-      refresh_token: tokens.refresh_token,
-      expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
-      token_type: 'Bearer',
+      access_token: fresh.access_token,
+      refresh_token: fresh.refresh_token,
+      expires_at: fresh.expires_at,
+      region: creds.region,
+      resource_url: fresh.resource_url ?? creds.resource_url,
       account: creds.account,
     };
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -52,6 +52,7 @@ export function loadConfig(flags: GlobalFlags): Config {
   const baseUrl = flags.baseUrl
     || process.env.MINIMAX_BASE_URL
     || file.base_url
+    || file.oauth?.resource_url
     || REGIONS[region]
     || REGIONS.global;
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -11,10 +11,6 @@ export function getConfigPath(): string {
   return join(getConfigDir(), 'config.json');
 }
 
-export function getCredentialsPath(): string {
-  return join(getConfigDir(), 'credentials.json');
-}
-
 export async function ensureConfigDir(): Promise<void> {
   const dir = getConfigDir();
   const fs = await import('fs/promises');

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -8,7 +8,23 @@ export const DOCS_HOSTS = {
   cn: 'https://platform.minimaxi.com',
 } as const;
 
+export const OAUTH_HOSTS = {
+  global: 'https://account.minimax.io',
+  cn: 'https://account.minimaxi.com',
+} as const;
+
 export type Region = keyof typeof REGIONS;
+
+export interface OAuthCredentials {
+  access_token: string;
+  refresh_token: string;
+  expires_at: string;        // ISO 8601
+  region?: Region;            // which OAuth host (defaults to 'global' if absent)
+  resource_url?: string;      // optional API host override returned by server
+  account?: string;
+  /** @deprecated Always 'Bearer'. Kept for backward compat with older fixtures. */
+  token_type?: 'Bearer';
+}
 
 export interface ConfigFile {
   api_key?: string;
@@ -17,6 +33,7 @@ export interface ConfigFile {
   output?: 'text' | 'json';
   timeout?: number;
   proxy?: string;
+  oauth?: OAuthCredentials;
   default_text_model?: string;
   default_speech_model?: string;
   default_video_model?: string;
@@ -25,6 +42,23 @@ export interface ConfigFile {
 
 const VALID_REGIONS = new Set<string>(['global', 'cn']);
 const VALID_OUTPUTS = new Set<string>(['text', 'json']);
+
+function parseOAuth(raw: unknown): OAuthCredentials | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.access_token !== 'string' || !o.access_token) return undefined;
+  if (typeof o.refresh_token !== 'string') return undefined;
+  if (typeof o.expires_at !== 'string') return undefined;
+  const out: OAuthCredentials = {
+    access_token: o.access_token,
+    refresh_token: o.refresh_token,
+    expires_at: o.expires_at,
+  };
+  if (typeof o.region === 'string' && VALID_REGIONS.has(o.region)) out.region = o.region as Region;
+  if (typeof o.resource_url === 'string' && o.resource_url.startsWith('http')) out.resource_url = o.resource_url;
+  if (typeof o.account === 'string' && o.account.length > 0) out.account = o.account;
+  return out;
+}
 
 export function parseConfigFile(raw: unknown): ConfigFile {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
@@ -37,6 +71,8 @@ export function parseConfigFile(raw: unknown): ConfigFile {
   if (typeof obj.output === 'string' && VALID_OUTPUTS.has(obj.output)) out.output = obj.output as ConfigFile['output'];
   if (typeof obj.timeout === 'number' && obj.timeout > 0) out.timeout = obj.timeout;
   if (typeof obj.proxy === 'string' && obj.proxy.startsWith('http')) out.proxy = obj.proxy;
+  const oauth = parseOAuth(obj.oauth);
+  if (oauth) out.oauth = oauth;
   if (typeof obj.default_text_model === 'string' && obj.default_text_model.length > 0) out.default_text_model = obj.default_text_model;
   if (typeof obj.default_speech_model === 'string' && obj.default_speech_model.length > 0) out.default_speech_model = obj.default_speech_model;
   if (typeof obj.default_video_model === 'string' && obj.default_video_model.length > 0) out.default_video_model = obj.default_video_model;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { detectRegion, saveDetectedRegion } from './config/detect-region';
 import { REGIONS, type Region } from './config/schema';
 import { checkForUpdate, getPendingUpdateNotification } from './update/checker';
 import { loadCredentials } from './auth/credentials';
-import { ensureApiKey } from './auth/setup';
+import { ensureAuth } from './auth/setup';
 import { CLI_VERSION } from './version';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
@@ -75,7 +75,8 @@ async function main() {
       await quotaCmd.execute(config, flags);
     } else {
       process.stderr.write('  Not logged in.\n');
-      process.stderr.write('  mmx auth login --api-key sk-xxxxx\n\n');
+      process.stderr.write('  mmx auth login              Choose MiniMax / MiniMaxCN OAuth or paste an API key\n');
+      process.stderr.write('  mmx auth login --api-key    Save an API key directly\n\n');
     }
     process.exit(0);
   }
@@ -91,7 +92,7 @@ async function main() {
     (cmd) => cmd.every((c, i) => commandPath[i] === c),
   );
   if (needsAuthSetup) {
-    await ensureApiKey(config);
+    await ensureAuth(config);
   }
 
   if (config.needsRegionDetection) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ async function main() {
       await quotaCmd.execute(config, flags);
     } else {
       process.stderr.write('  Not logged in.\n');
-      process.stderr.write('  mmx auth login              Choose MiniMax / MiniMaxCN OAuth or paste an API key\n');
+      process.stderr.write('  mmx auth login              Choose MiniMax OAuth (Global/China) or paste an API key\n');
       process.stderr.write('  mmx auth login --api-key    Save an API key directly\n\n');
     }
     process.exit(0);

--- a/src/output/status-bar.ts
+++ b/src/output/status-bar.ts
@@ -20,12 +20,16 @@ function tildePath(p: string): string {
   return p.startsWith(homedir()) ? p.replace(homedir(), '~') : p;
 }
 
+function stripScheme(url: string): string {
+  return url.replace(/^https?:\/\//, '');
+}
+
 export function maybeShowStatusBar(config: Config, token: string, model?: string): void {
   if (config.quiet || printed || !process.stderr.isTTY) return;
   printed = true;
 
   const filePath   = config.configPath ? tildePath(config.configPath) : '~/.mmx/config.json';
-  const regionSrc  = config.fileRegion ? `${config.fileRegion} (file)` : 'global (default)';
+  const baseUrlStr = stripScheme(config.baseUrl);
   const keySrc     = config.apiKey ? '(flag)' : '(file)';
   const maskedKey  = maskToken(token);
   const modelStr   = model ? ` ${dim}|${reset} ${dim}Model:${reset} ${mmPurple}${model}${reset}` : '';
@@ -34,7 +38,7 @@ export function maybeShowStatusBar(config: Config, token: string, model?: string
     `${bold}${mmBlue}MINIMAX${reset} ` +
     `${dim}${filePath}${reset} ` +
     `${dim}|${reset} ` +
-    `${dim}Region:${reset} ${mmCyan}${regionSrc}${reset} ` +
+    `${dim}URL:${reset} ${mmCyan}${baseUrlStr}${reset} ` +
     `${dim}|${reset} ` +
     `${dim}Key:${reset} ${mmPink}${maskedKey}${reset} ${dim}${keySrc}${reset}` +
     `${modelStr}\n`,

--- a/test/auth/timeout-fix.test.ts
+++ b/test/auth/timeout-fix.test.ts
@@ -127,7 +127,7 @@ describe('refreshAccessToken: timeout and error handling', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString();
-      if (url.includes('oauth/token')) {
+      if (url.includes('oauth2/token') || url.includes('oauth/token')) {
         return origFetch(`${server.url}/v1/oauth/token`, init);
       }
       return origFetch(input, init);
@@ -147,10 +147,10 @@ describe('refreshAccessToken: timeout and error handling', () => {
       routes: {
         '/v1/oauth/token': () =>
           jsonResponse({
+            status: 'success',
             access_token: 'new-access-token',
             refresh_token: 'new-refresh-token',
-            expires_in: 3600,
-            token_type: 'Bearer',
+            expired_in: Date.now() + 3600 * 1000,
           }),
       },
     });
@@ -160,7 +160,7 @@ describe('refreshAccessToken: timeout and error handling', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString();
-      if (url.includes('oauth/token')) {
+      if (url.includes('oauth2/token') || url.includes('oauth/token')) {
         return origFetch(`${server.url}/v1/oauth/token`, init);
       }
       return origFetch(input, init);
@@ -169,7 +169,7 @@ describe('refreshAccessToken: timeout and error handling', () => {
     try {
       const tokens = await mod.refreshAccessToken('valid-refresh-token');
       expect(tokens.access_token).toBe('new-access-token');
-      expect(tokens.expires_in).toBe(3600);
+      expect(typeof tokens.expires_at).toBe('string');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -7,7 +7,7 @@ describe('auth login command', () => {
     expect(loginCommand.description).toContain('Authenticate');
   });
 
-  it('requires api key when method is api-key', async () => {
+  it('requires api key in non-interactive mode', async () => {
     const config = {
       region: 'global' as const,
       baseUrl: 'https://api.mmx.io',
@@ -24,7 +24,6 @@ describe('auth login command', () => {
 
     await expect(
       loginCommand.execute(config, {
-        method: 'api-key',
         quiet: false,
         verbose: false,
         noColor: true,


### PR DESCRIPTION
## Summary

End-to-end OAuth 2.0 Device Authorization Grant against the MiniMax account servers (`account.minimax.io` / `account.minimaxi.com`), wired into `mmx auth login` via a single first-run menu:

```
?  How would you like to authenticate?
   ▸ MiniMax     ·  OAuth login (Global)
     MiniMaxCN  ·  OAuth login (China)
     API key    ·  Paste sk-cp-... or sk-...
```

Tokens are persisted into `~/.mmx/config.json` under an `oauth` subobject. No separate `credentials.json` file — logout clears one place and users have a single file to back up.

This is an alternative to #134, written from scratch on top of `main` so it doesn't inherit any of the rough edges from that branch.

## Highlights

- **Single 3-option menu** — no two-step "method → region" sequence
- **Browser opened safely** — `execFile`/`spawn`, never `exec()` with template-string interpolation of the auth-server URL (preserves the #79 fix)
- **No `Config.oauthApiHost` field** — the OAuth host is derived from the region stored in the saved credentials. No required Config field means **zero test-fixture churn**.
- **Honest field naming** — `expires_at` (ISO 8601) at every API boundary; the badly-named server field `expired_in` (which is actually a Unix-ms timestamp) is converted on the spot inside `oauth.ts` / `refresh.ts` and never leaks.
- **No `BEDROCK_LANE` / `X-User-Pre`** env-var sprinkles — those are internal/staging concerns that don't belong in the public CLI.
- **Dead code removed** — the unused browser-callback flow (Authorization Code + local server on port 18991) is deleted; CLIs use device-code, not redirect.

## Diff

```
src/auth/oauth.ts                 device-code flow against /oauth2/{device/code,token}
src/auth/refresh.ts               refresh derived from creds.region
src/auth/setup.ts                 single 3-option menu
src/auth/credentials.ts           reads/writes the oauth subobject of config.json
src/auth/resolver.ts              source label "config.json"
src/auth/types.ts                 CredentialFile = OAuthCredentials alias
src/commands/auth/login.ts        same menu; --api-key for non-interactive
src/commands/auth/logout.ts       clears oauth from config.json
src/commands/auth/refresh.ts      uses creds.region
src/config/schema.ts              OAuthCredentials type + OAUTH_HOSTS + parser
src/config/loader.ts              baseUrl falls back to oauth.resource_url
src/config/paths.ts               drops getCredentialsPath
src/main.ts                       calls ensureAuth
test/auth/timeout-fix.test.ts     mock body/URL aligned with new shape
test/commands/auth/login.test.ts  assertion updated for new flag layout
```

15 files, **-27 lines net** (`+371 / -398`).

## `~/.mmx/config.json` schema

```jsonc
{
  "api_key": "sk-cp-...",          // optional, as before
  "region": "global",
  "oauth": {                       // new — was a separate credentials.json
    "access_token": "...",
    "refresh_token": "...",
    "expires_at": "2026-05-15T12:34:56Z",
    "region": "global",            // OAuth host this token came from
    "resource_url": "https://api.minimax.io"
  },
  "base_url": "...",
  "output": "text"
}
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` 212 / 212 pass
- [x] `bun run lint` clean
- [x] `bun run build` produces `dist/mmx.mjs` (137 KB)
- [x] `mmx auth login` (CN region) — interactive OAuth completes, tokens land in `~/.mmx/config.json` `oauth` subobject
- [x] `mmx auth status` — reads back: Method `oauth`, Source `config.json`
- [x] `mmx auth logout` — clears `oauth` from `config.json` (api_key untouched if present)

## Relationship to #134

Same goal, independent implementation. Reviewers can pick whichever they prefer; this branch is rebased cleanly on `main` and intentionally avoids the issues called out in #134's review (separate JSON file, required Config field, exec() shell-injection regression, internal env-var leakage, mismatched field naming).