### PR TITLE
feat: add audio file save support to SpeechSDK and MusicSDK

### DIFF
--- a/src/sdk/music/index.ts
+++ b/src/sdk/music/index.ts
@@ -1,3 +1,5 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
 import { Client } from "../client";
 import { musicEndpoint } from "../../client/endpoints";
 import { MusicRequest, MusicResponse } from "../../types/api";
@@ -6,6 +8,21 @@ import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
 import { toMerged } from "es-toolkit/object";
 import { musicGenerateModel } from "../../commands/music/models";
+
+function hexToBuffer(hex: string): Buffer {
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new SDKError('API returned invalid audio data (not valid hex).', ExitCode.GENERAL);
+  }
+  if (hex.length % 2 !== 0) {
+    throw new SDKError('API returned truncated audio data (odd-length hex string).', ExitCode.GENERAL);
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+function defaultFilename(prefix: string, ext: string): string {
+  const ts = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
+  return `${prefix}_${ts}.${ext}`;
+}
 
 export interface MusicGenerateRequest extends MusicRequest {
   /** Vocal style, e.g. "warm male baritone", "bright female soprano", "duet with harmonies" */
@@ -79,6 +96,38 @@ export class MusicSDK extends Client {
       method: 'POST',
       body,
     });
+  }
+
+  /**
+   * Save generated music audio to a file. Decodes the hex-encoded audio
+   * from the API response and writes it to disk. Creates intermediate
+   * directories as needed.
+   *
+   * @param response — The response from `generate()`.
+   * @param outPath  — Target file path. Defaults to `music_<timestamp>.mp3`.
+   * @param ext      — File extension (default: `"mp3"`).
+   * @returns The absolute path of the saved file.
+   */
+  save(response: MusicResponse, outPath?: string, ext = 'mp3'): string {
+    const dest = resolve(outPath || defaultFilename('music', ext));
+    const audioHex = response.data.audio;
+    if (!audioHex) {
+      throw new SDKError('API response missing audio data.', ExitCode.GENERAL);
+    }
+
+    const dir = dirname(dest);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+    try {
+      writeFileSync(dest, hexToBuffer(audioHex));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+        throw new SDKError('Disk full — cannot write audio file.', ExitCode.GENERAL);
+      }
+      throw err;
+    }
+
+    return dest;
   }
 
   private buildPrompt(request: ModelPartial<MusicGenerateRequest>) {

--- a/src/sdk/speech/index.ts
+++ b/src/sdk/speech/index.ts
@@ -1,3 +1,5 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
 import { Client } from "../client";
 import { speechEndpoint, voicesEndpoint } from "../../client/endpoints";
 import { SpeechRequest, SpeechResponse, VoiceListResponse } from "../../types/api";
@@ -6,6 +8,21 @@ import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
 import { toMerged } from "es-toolkit/object";
 import { ModelPartial } from "../types";
+
+function hexToBuffer(hex: string): Buffer {
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new SDKError('API returned invalid audio data (not valid hex).', ExitCode.GENERAL);
+  }
+  if (hex.length % 2 !== 0) {
+    throw new SDKError('API returned truncated audio data (odd-length hex string).', ExitCode.GENERAL);
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+function defaultFilename(prefix: string, ext: string): string {
+  const ts = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
+  return `${prefix}_${ts}.${ext}`;
+}
 
 export class SpeechSDK extends Client {
   async synthesize(request: ModelPartial<SpeechRequest> & { stream: true }): Promise<AsyncGenerator<SpeechResponse>>;
@@ -54,6 +71,38 @@ export class SpeechSDK extends Client {
       return filtered;
     }
     return voices;
+  }
+
+  /**
+   * Save synthesized speech audio to a file. Decodes the hex-encoded audio
+   * from the API response and writes it to disk. Creates intermediate
+   * directories as needed.
+   *
+   * @param response — The response from `synthesize()`.
+   * @param outPath  — Target file path. Defaults to `speech_<timestamp>.mp3`.
+   * @param ext      — File extension (default: `"mp3"`).
+   * @returns The absolute path of the saved file.
+   */
+  save(response: SpeechResponse, outPath?: string, ext = 'mp3'): string {
+    const dest = resolve(outPath || defaultFilename('speech', ext));
+    const audioHex = response.data.audio;
+    if (!audioHex) {
+      throw new SDKError('API response missing audio data.', ExitCode.GENERAL);
+    }
+
+    const dir = dirname(dest);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+    try {
+      writeFileSync(dest, hexToBuffer(audioHex));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOSPC') {
+        throw new SDKError('Disk full — cannot write audio file.', ExitCode.GENERAL);
+      }
+      throw err;
+    }
+
+    return dest;
   }
 
   private validateParams(params: Partial<SpeechRequest>): SpeechRequest {

--- a/test/sdk/music.test.ts
+++ b/test/sdk/music.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { createMockServer, jsonResponse, type MockServer } from '../helpers/mock-server';
 import { MiniMaxSDK } from '../../src/sdk';
+import { MusicSDK } from '../../src/sdk/music';
+import { existsSync, unlinkSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { MusicResponse } from '../../src/types/api';
+
+function makeMusicResponse(hexAudio?: string): MusicResponse {
+  return {
+    base_resp: { status_code: 0, status_msg: 'ok' },
+    data: {
+      audio: hexAudio || Buffer.from('hello music audio').toString('hex'),
+      status: 0,
+    },
+  };
+}
 
 describe('MiniMaxSDK.music', () => {
   let server: MockServer;
@@ -30,5 +45,42 @@ describe('MiniMaxSDK.music', () => {
     });
 
     expect(result.data.audio_url).toBe('https://example.com/music.mp3');
+  });
+});
+
+describe('MusicSDK.save', () => {
+  const sdk = new MusicSDK({ apiKey: 'sk-test', region: 'global' });
+
+  it('decodes hex audio and saves to disk', () => {
+    const out = join(tmpdir(), `music-sdk-save-${Date.now()}.mp3`);
+    const response = makeMusicResponse();
+
+    const saved = sdk.save(response, out);
+    expect(saved).toBe(out);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out).toString()).toBe('hello music audio');
+    unlinkSync(out);
+  });
+
+  it('generates default filename with timestamp', () => {
+    const response = makeMusicResponse();
+    const saved = sdk.save(response);
+    expect(saved).toMatch(/music_\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.mp3/);
+    expect(existsSync(saved)).toBe(true);
+    unlinkSync(saved);
+  });
+
+  it('creates intermediate directories', () => {
+    const out = join(tmpdir(), `music-sdk-deep-${Date.now()}`, 'x', 'y', 'song.wav');
+    const response = makeMusicResponse();
+    const saved = sdk.save(response, out, 'wav');
+    expect(existsSync(saved)).toBe(true);
+    unlinkSync(saved);
+  });
+
+  it('throws when audio data is missing', () => {
+    const response = makeMusicResponse('');
+    response.data.audio = undefined;
+    expect(() => sdk.save(response, '/tmp/test.mp3')).toThrow('missing audio data');
   });
 });

--- a/test/sdk/speech.test.ts
+++ b/test/sdk/speech.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { createMockServer, jsonResponse, type MockServer } from '../helpers/mock-server';
 import { MiniMaxSDK } from '../../src/sdk';
+import { SpeechSDK } from '../../src/sdk/speech';
+import { existsSync, unlinkSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { SpeechResponse } from '../../src/types/api';
+
+function makeSpeechResponse(hexAudio?: string): SpeechResponse {
+  return {
+    base_resp: { status_code: 0, status_msg: 'ok' },
+    data: {
+      audio: hexAudio || Buffer.from('hello speech audio').toString('hex'),
+      status: 0,
+    },
+  };
+}
 
 describe('MiniMaxSDK.speech', () => {
   let server: MockServer;
@@ -52,5 +67,42 @@ describe('MiniMaxSDK.speech', () => {
 
     expect(voices).toHaveLength(1);
     expect(voices[0].voice_id).toBe('voice-1');
+  });
+});
+
+describe('SpeechSDK.save', () => {
+  const sdk = new SpeechSDK({ apiKey: 'sk-test', region: 'global' });
+
+  it('decodes hex audio and saves to disk', () => {
+    const out = join(tmpdir(), `speech-sdk-save-${Date.now()}.mp3`);
+    const response = makeSpeechResponse();
+
+    const saved = sdk.save(response, out);
+    expect(saved).toBe(out);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out).toString()).toBe('hello speech audio');
+    unlinkSync(out);
+  });
+
+  it('generates default filename with timestamp', () => {
+    const response = makeSpeechResponse();
+    const saved = sdk.save(response);
+    expect(saved).toMatch(/speech_\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.mp3/);
+    expect(existsSync(saved)).toBe(true);
+    unlinkSync(saved);
+  });
+
+  it('creates intermediate directories', () => {
+    const out = join(tmpdir(), `speech-sdk-deep-${Date.now()}`, 'a', 'b', 'out.wav');
+    const response = makeSpeechResponse();
+    const saved = sdk.save(response, out, 'wav');
+    expect(existsSync(saved)).toBe(true);
+    unlinkSync(saved);
+  });
+
+  it('throws when audio data is missing', () => {
+    const response = makeSpeechResponse('');
+    response.data.audio = undefined;
+    expect(() => sdk.save(response, '/tmp/test.mp3')).toThrow('missing audio data');
   });
 });


### PR DESCRIPTION
## Summary

Closes #146

Adds `save()` methods to `SpeechSDK` and `MusicSDK` that decode hex-encoded audio from API responses and write it to disk.

## Motivation

Both `synthesize()` and `generate()` return hex strings in `response.data.audio`. Saving these to files currently requires users to:

1. Validate hex format manually
2. Decode with `Buffer.from(hex, 'hex')`
3. Create output directories
4. Generate filenames
5. Handle disk-full errors

This is boilerplate the CLI already handles. The SDK should too.

## Usage

```typescript
import { MiniMaxSDK } from 'mmx-cli/sdk';

const sdk = new MiniMaxSDK({ apiKey: 'sk-...' });

// Speech
const tts = await sdk.speech.synthesize({ text: 'Hello world!' });
const speechPath = sdk.speech.save(tts);
// → speech_2026-05-13-15-30-00.mp3

// Or with explicit path
sdk.speech.save(tts, '/tmp/greeting.wav', 'wav');

// Music
const music = await sdk.music.generate({ prompt: 'Upbeat pop', lyrics: '...' });
const musicPath = sdk.music.save(music);
// → music_2026-05-13-15-31-00.mp3
```

## Files changed

| File | Change |
|------|--------|
| `src/sdk/speech/index.ts` | +50 lines — `save()` method + shared hex helpers |
| `src/sdk/music/index.ts` | +55 lines — `save()` method + shared hex helpers |
| `test/sdk/speech.test.ts` | +35 lines — 4 save test cases |
| `test/sdk/music.test.ts` | +35 lines — 4 save test cases |

## Screenshots

<!-- TODO: add screenshots here -->