### PR TITLE
test: avoid /dev/null in command tests

### DIFF
--- a/test/commands/file/upload.test.ts
+++ b/test/commands/file/upload.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { default as uploadCommand } from '../../../src/commands/file/upload';
 
 const baseConfig = {
@@ -27,6 +30,22 @@ const baseFlags = {
   async: false,
 };
 
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stdout.write;
+  let output = '';
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+    return output;
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
 describe('file upload command', () => {
   it('has correct name', () => {
     expect(uploadCommand.name).toBe('file upload');
@@ -45,17 +64,22 @@ describe('file upload command', () => {
   });
 
   it('shows dry-run output with file info', async () => {
-    let captured = '';
-    const origWrite = process.stdout.write;
-    process.stdout.write = (chunk: any): any => { captured += String(chunk); return true; };
+    const tempDir = mkdtempSync(join(tmpdir(), 'mmx-upload-test-'));
+    const filePath = join(tempDir, 'fixture.bin');
+    writeFileSync(filePath, 'fixture');
 
-    await uploadCommand.execute(
-      { ...baseConfig, dryRun: true },
-      { ...baseFlags, dryRun: true, file: '/dev/null', purpose: 'vision' },
-    );
+    try {
+      const captured = await captureStdout(async () => {
+        await uploadCommand.execute(
+          { ...baseConfig, dryRun: true },
+          { ...baseFlags, dryRun: true, file: filePath, purpose: 'vision' },
+        );
+      });
 
-    process.stdout.write = origWrite;
-    expect(captured).toContain('/dev/null');
-    expect(captured).toContain('vision');
+      expect(captured).toContain(filePath);
+      expect(captured).toContain('vision');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/commands/music/generate.test.ts
+++ b/test/commands/music/generate.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { default as generateCommand } from '../../../src/commands/music/generate';
 
 const baseConfig = {
@@ -107,12 +110,20 @@ describe('music generate command', () => {
   });
 
   it('rejects --instrumental with --lyrics-file', async () => {
-    await expect(
-      generateCommand.execute(
-        { ...baseConfig, dryRun: true },
-        { ...baseFlags, prompt: 'Folk', instrumental: true, lyricsFile: '/dev/null' },
-      ),
-    ).rejects.toThrow('Cannot use --instrumental with --lyrics');
+    const tempDir = mkdtempSync(join(tmpdir(), 'mmx-lyrics-test-'));
+    const lyricsFile = join(tempDir, 'lyrics.txt');
+    writeFileSync(lyricsFile, 'Hello');
+
+    try {
+      await expect(
+        generateCommand.execute(
+          { ...baseConfig, dryRun: true },
+          { ...baseFlags, prompt: 'Folk', instrumental: true, lyricsFile },
+        ),
+      ).rejects.toThrow('Cannot use --instrumental with --lyrics');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('handles "无歌词" as instrumental', async () => {


### PR DESCRIPTION
## Summary

Replace hard-coded `/dev/null` test fixtures with temporary files created at runtime.

This makes the affected command tests portable across Windows and Unix-like environments.

## Changes

- Use a temporary fixture file in `file upload` dry-run output test.
- Use a temporary lyrics file in `music generate` validation test.
- Clean up temporary directories after each test.
- Reuse a typed stdout capture helper instead of assigning `process.stdout.write` with `any`.

## Why

`/dev/null` is available on Unix-like systems but not on Windows. When running the test suite on Windows, these tests fail before reaching the intended assertions.

## Testing

- `npx tsc --noEmit`
- `npx eslint test/commands/file/upload.test.ts test/commands/music/generate.test.ts`
- `npx bun test`  
  Result: 354 pass, 0 fail

## Notes

I also tried the local smoke compile with `npx bun build src/main.ts --compile --outfile dist/mmx-test`, but Bun failed on this Windows environment with `failed to copy bun executable into temporary file: ENOENT`. The full test suite and typecheck pass locally.