### PR TITLE
fix: handle cross-device config writes

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -12,6 +12,12 @@ interface RenameWithFallbackOps {
   unlink: (path: string) => void;
 }
 
+function isCrossDeviceError(err: unknown): err is Error & { code: 'EXDEV' } {
+  return err instanceof Error
+    && 'code' in err
+    && (err as { code?: string }).code === 'EXDEV';
+}
+
 export function renameWithCrossDeviceFallback(
   from: string,
   to: string,
@@ -24,7 +30,7 @@ export function renameWithCrossDeviceFallback(
   try {
     ops.rename(from, to);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    if (!isCrossDeviceError(err)) throw err;
     ops.copy(from, to);
     ops.unlink(from);
   }
@@ -44,12 +50,15 @@ export function readConfigFile(): ConfigFile {
   }
 }
 
-export async function writeConfigFile(data: Record<string, unknown>): Promise<void> {
+export async function writeConfigFile(
+  data: Record<string, unknown>,
+  renameOps?: RenameWithFallbackOps,
+): Promise<void> {
   await ensureConfigDir();
   const path = getConfigPath();
   const tmp = path + '.tmp';
   writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
-  renameWithCrossDeviceFallback(tmp, path);
+  renameWithCrossDeviceFallback(tmp, path, renameOps);
 }
 
 export function loadConfig(flags: GlobalFlags): Config {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,10 +1,34 @@
-import { readFileSync, writeFileSync, renameSync, existsSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { parseConfigFile, REGIONS, type Config, type ConfigFile, type Region } from './schema';
 import { ensureConfigDir, getConfigPath } from './paths';
 import { detectOutputFormat, type OutputFormat } from '../output/formatter';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 import type { GlobalFlags } from '../types/flags';
+
+interface RenameWithFallbackOps {
+  rename: (from: string, to: string) => void;
+  copy: (from: string, to: string) => void;
+  unlink: (path: string) => void;
+}
+
+export function renameWithCrossDeviceFallback(
+  from: string,
+  to: string,
+  ops: RenameWithFallbackOps = {
+    rename: renameSync,
+    copy: copyFileSync,
+    unlink: unlinkSync,
+  },
+): void {
+  try {
+    ops.rename(from, to);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    ops.copy(from, to);
+    ops.unlink(from);
+  }
+}
 
 export function readConfigFile(): ConfigFile {
   const path = getConfigPath();
@@ -25,7 +49,7 @@ export async function writeConfigFile(data: Record<string, unknown>): Promise<vo
   const path = getConfigPath();
   const tmp = path + '.tmp';
   writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
-  renameSync(tmp, path);
+  renameWithCrossDeviceFallback(tmp, path);
 }
 
 export function loadConfig(flags: GlobalFlags): Config {

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, rmSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { loadConfig } from '../../src/config/loader';
+import { loadConfig, renameWithCrossDeviceFallback, writeConfigFile } from '../../src/config/loader';
 import { CLIError } from '../../src/errors/base';
 import type { GlobalFlags } from '../../src/types/flags';
 
@@ -55,5 +55,75 @@ describe('loadConfig', () => {
 
     expect(config.region).toBe('cn');
     expect(config.baseUrl).toBe('https://api.minimaxi.com');
+  });
+});
+
+describe('writeConfigFile', () => {
+  const testDir = join(tmpdir(), `mmx-config-write-test-${Date.now()}`);
+  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+
+  beforeEach(() => {
+    process.env.MMX_CONFIG_DIR = testDir;
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.MMX_CONFIG_DIR;
+    else process.env.MMX_CONFIG_DIR = originalConfigDir;
+    rmSync(testDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  it('falls back to copy and unlink when rename crosses devices', async () => {
+    const calls: string[] = [];
+    const renameMock = mock((from: string, _to: string) => {
+      calls.push(`rename:${from}`);
+      const err = new Error('cross-device link not permitted') as NodeJS.ErrnoException;
+      err.code = 'EXDEV';
+      err.path = from;
+      throw err;
+    });
+    const copyMock = mock((from: string, _to: string) => {
+      calls.push(`copy:${from}`);
+    });
+    const unlinkMock = mock((path: string) => {
+      calls.push(`unlink:${path}`);
+    });
+
+    renameWithCrossDeviceFallback('config.json.tmp', 'config.json', {
+      rename: renameMock,
+      copy: copyMock,
+      unlink: unlinkMock,
+    });
+
+    expect(renameMock).toHaveBeenCalledTimes(1);
+    expect(copyMock).toHaveBeenCalledTimes(1);
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([
+      'rename:config.json.tmp',
+      'copy:config.json.tmp',
+      'unlink:config.json.tmp',
+    ]);
+  });
+
+  it('rethrows non-EXDEV rename errors', () => {
+    const renameMock = mock(() => {
+      const err = new Error('permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+
+    expect(() => renameWithCrossDeviceFallback('config.json.tmp', 'config.json', {
+      rename: renameMock,
+      copy: mock(() => {}),
+      unlink: mock(() => {}),
+    })).toThrow('permission denied');
+  });
+
+  it('uses atomic rename on the normal path', async () => {
+    await writeConfigFile({ output: 'json' });
+
+    const configPath = join(testDir, 'config.json');
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).output).toBe('json');
   });
 });

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdirSync, readFileSync, rmSync } from 'fs';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadConfig, renameWithCrossDeviceFallback, writeConfigFile } from '../../src/config/loader';
@@ -104,6 +104,35 @@ describe('writeConfigFile', () => {
       'copy:config.json.tmp',
       'unlink:config.json.tmp',
     ]);
+  });
+
+  it('writes the config file when the final rename crosses devices', async () => {
+    const renameMock = mock((from: string, _to: string) => {
+      const err = new Error('cross-device link not permitted') as Error & {
+        code?: string;
+        path?: string;
+      };
+      err.code = 'EXDEV';
+      err.path = from;
+      throw err;
+    });
+    const copyMock = mock((from: string, to: string) => copyFileSync(from, to));
+    const unlinkMock = mock((path: string) => unlinkSync(path));
+
+    await writeConfigFile({ region: 'cn', output: 'json' }, {
+      rename: renameMock,
+      copy: copyMock,
+      unlink: unlinkMock,
+    });
+
+    const configPath = join(testDir, 'config.json');
+    const parsed = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+    expect(renameMock).toHaveBeenCalledTimes(1);
+    expect(copyMock).toHaveBeenCalledTimes(1);
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+    expect(parsed.region).toBe('cn');
+    expect(parsed.output).toBe('json');
   });
 
   it('rethrows non-EXDEV rename errors', () => {


### PR DESCRIPTION
## Summary

Fix config writes when `renameSync(tmp, path)` fails with `EXDEV`.

This addresses #61.

## Changes

- Keep the existing atomic `renameSync` path for normal config writes.
- Add an `EXDEV` fallback that copies the temp config file to the final path and then removes the temp file.
- Preserve existing behavior for non-`EXDEV` errors by rethrowing them.
- Add tests for:
  - EXDEV fallback behavior.
  - Non-EXDEV error rethrowing.
  - Normal config write path.

## Why

Issue #61 reports:

```text
EXDEV: cross-device link not permitted, rename '...\config.json.tmp' -> '...\config.json'