### PR TITLE
feat(quota): align types with coding-plan API, show boost multiplier

### DIFF
--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -128,7 +128,10 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
   const L = config.region === 'cn' ? LABELS_CN : LABELS_EN;
 
   const rows = models.map((m) => {
-    const displayName = displayModelName(m.model_name, config.region);
+    const baseName = displayModelName(m.model_name, config.region);
+    const boost = m.interval_boost_permille;
+    const boostTag = (boost && boost > 1000) ? ` ×${boost / 1000}` : '';
+    const displayName = baseName + boostTag;
     const current = renderMetric(
       L.current,
       m.current_interval_usage_count,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -253,9 +253,13 @@ export interface QuotaModelRemain {
   current_interval_total_count: number;
   current_interval_usage_count: number;
   current_interval_remaining_percent?: number;
+  current_interval_status?: number;
   current_weekly_total_count: number;
   current_weekly_usage_count: number;
   current_weekly_remaining_percent?: number;
+  current_weekly_status?: number;
+  interval_boost_permille?: number;
+  weekly_boost_permille?: number;
   weekly_start_time: number;
   weekly_end_time: number;
   weekly_remains_time: number;

--- a/test/output/quota-table.test.ts
+++ b/test/output/quota-table.test.ts
@@ -47,9 +47,13 @@ function createCodingPlanModels(): QuotaModelRemain[] {
       current_interval_total_count: 0,
       current_interval_usage_count: 0,
       current_interval_remaining_percent: 94,
+      current_interval_status: 1,
       current_weekly_total_count: 0,
       current_weekly_usage_count: 0,
       current_weekly_remaining_percent: 98,
+      current_weekly_status: 1,
+      interval_boost_permille: 2000,
+      weekly_boost_permille: 2000,
       weekly_start_time: Date.UTC(2026, 4, 31, 0, 0, 0),
       weekly_end_time: Date.UTC(2026, 5, 7, 0, 0, 0),
       weekly_remains_time: 6 * 24 * 60 * 60 * 1000,
@@ -128,5 +132,72 @@ describe('renderQuotaTable', () => {
     expect(output).toContain('3 / 3');
     expect(output).toContain('21 / 21');
     expect(output).not.toContain('0 / 3');
+  });
+
+  it('renders boost multiplier when boost_permille > 1000', () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(createCodingPlanModels(), {
+        ...createConfig(),
+        region: 'cn',
+        noColor: true,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+
+    // general model has interval_boost_permille=2000 => ×2 prefix
+    expect(output).toContain('通用 ×2');
+    // video model has no boost field => no ×2 on its row
+    // ensure the video line is still present (so the negative check is meaningful)
+    expect(output).toContain('视频');
+  });
+
+  it('omits boost multiplier when boost_permille is missing', () => {
+    const modelsNoBoost: QuotaModelRemain[] = [{
+      model_name: 'general',
+      start_time: Date.UTC(2026, 4, 31, 0, 0, 0),
+      end_time: Date.UTC(2026, 4, 31, 2, 0, 0),
+      remains_time: 2 * 60 * 60 * 1000,
+      current_interval_total_count: 100,
+      current_interval_usage_count: 50,
+      current_interval_remaining_percent: 50,
+      current_weekly_total_count: 1000,
+      current_weekly_usage_count: 200,
+      current_weekly_remaining_percent: 80,
+      weekly_start_time: Date.UTC(2026, 4, 31, 0, 0, 0),
+      weekly_end_time: Date.UTC(2026, 5, 7, 0, 0, 0),
+      weekly_remains_time: 6 * 24 * 60 * 60 * 1000,
+    }];
+
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(modelsNoBoost, {
+        ...createConfig(),
+        region: 'cn',
+        noColor: true,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+
+    expect(output).toContain('通用');
+    expect(output).not.toContain('×2');
   });
 });


### PR DESCRIPTION
## Background

PR #166 (commit 57c09c7) switched the quota endpoint to /v1/api/openplatform/coding_plan/remains and added *_remaining_percent to QuotaModelRemain. But the actual API response includes 4 additional fields that were not declared or rendered:

- current_interval_status (number, observed 1 = partial / 3 = full)
- current_weekly_status (number, observed 1 = partial / 3 = full)
- interval_boost_permille (number, e.g. 2000 = 2x base)
- weekly_boost_permille (number, e.g. 2000 = 2x base)

## Observed data (3 API calls, Max subscription)

| Field | general (5h) | general (weekly) | video |
|------|-------------|-----------------|-------|
| *_status | 1 (87% remaining) | 1->3 (98%->100%) | 3 (100% remaining) |
| *_boost_permille | 2000 | 2000 | absent |

When *_remaining_percent hit 100%, *_status flipped from 1 to 3 — so the status is a percent mapping (1=partial, 3=full), not an independent state field. The percent color display already conveys this, so we don't render status separately.

## Changes

1. src/types/api.ts: Add 4 optional fields to QuotaModelRemain
2. src/output/quota-table.ts: When boost_permille > 1000, prepend xN to the model name (e.g. "通用 x2")
3. test/output/quota-table.test.ts: Add 2 test cases covering with-boost and without-boost rendering

## Open questions for maintainers

- Are there other status enum values (0/2/4) we haven't observed? Our account has never exhausted the quota.
- Is boost_permille stable across all subscription tiers, or only certain ones (we have Max data)?
- Should the boost tag position be next to model name (current), or in a separate column?

Refs #166