### PR TITLE
docs(search): document the 10-result cap on mmx search query (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ mmx search "MiniMax AI"
 mmx search query --q "latest news" --output json
 ```
 
+> The `/v1/coding_plan/search` API returns at most 10 results per call and does not currently expose a pagination parameter (see #107). Refine your query if you need different results.
+
 ### `mmx auth`
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -130,6 +130,8 @@ mmx search "MiniMax AI"
 mmx search query --q "最新动态" --output json
 ```
 
+> `/v1/coding_plan/search` 接口单次最多返回 10 条结果，目前不支持翻页参数（参见 #107）。如需不同结果，请调整查询关键词。
+
 ### `mmx auth`
 
 ```bash

--- a/SDK.md
+++ b/SDK.md
@@ -171,6 +171,8 @@ for (const item of results.organic) {
 }
 ```
 
+> The underlying `/v1/coding_plan/search` API returns at most 10 results per call and does not currently expose a pagination parameter (see #107). Refine your query if you need different results.
+
 ### Quota
 
 ```typescript

--- a/src/commands/search/query.ts
+++ b/src/commands/search/query.ts
@@ -20,7 +20,11 @@ interface SearchResponse {
 
 export default defineCommand({
   name: 'search query',
-  description: 'Search the web via MiniMax',
+  description:
+    'Search the web via MiniMax. ' +
+    'Note: the underlying /v1/coding_plan/search API returns at most 10 ' +
+    'results per call and does not currently support pagination, so ' +
+    'refining your --q is the only way to see different results.',
   usage: 'mmx search query --q <query>',
   options: [
     { flag: '--q <query>', description: 'Search query string' },


### PR DESCRIPTION
## Summary

- `mmx search query`'s `description` now spells out the 10-result cap and tells users to refine `--q` if they need different results.
- `README.md`, `README_CN.md`, and `SDK.md` get a short note next to the search section making the cap visible.

## Why this is a docs-only PR

I investigated the `/v1/coding_plan/search` endpoint before writing code. The canonical reference client is `MiniMax-AI/MiniMax-Coding-Plan-MCP/minimax_mcp/server.py`, where `web_search(query: str)` only sends `{"q": query}`. The response is `{ organic: [...], related_searches: [...] }` — no `count`, `page`, `limit`, or `offset` is accepted or returned.

In other words, the 10-result cap is a hard API limit, not a CLI limitation. Adding `--page` / `--limit` flags to the CLI would not actually paginate — the server would ignore them. So this PR is intentionally docs-only.

A follow-up issue has been filed at #169 tracking the API-side work needed to make pagination viable.

## Changes

- `src/commands/search/query.ts` — extend the command's `description` (shown in `--help`) to call out the 10-result cap.
- `README.md` / `README_CN.md` — add a one-line note in the `mmx search` section.
- `SDK.md` — add the same note in the Search subsection.

## Test plan

- [x] `bun test` — 355 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — only the 2 pre-existing errors on `upstream/main` (unrelated to this PR)
- No new tests needed: this change is description text in a command and prose in docs, with no behavior change.

Refs #107.