### PR TITLE
fix(quota): use /v1/token_plan/remains and honor custom base URL

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -39,9 +39,7 @@ export function vlmEndpoint(baseUrl: string): string {
 }
 
 export function quotaEndpoint(baseUrl: string): string {
-  // Quota endpoint uses api subdomain
-  const host = baseUrl.includes('minimaxi.com') ? 'https://api.minimaxi.com' : 'https://api.minimax.io';
-  return `${host}/v1/api/openplatform/coding_plan/remains`;
+  return `${baseUrl}/v1/token_plan/remains`;
 }
 
 export function fileUploadEndpoint(baseUrl: string): string {

--- a/src/config/detect-region.ts
+++ b/src/config/detect-region.ts
@@ -1,7 +1,7 @@
 import { REGIONS, type Region } from "./schema";
 import { readConfigFile, writeConfigFile } from "./loader";
 
-const QUOTA_PATH = "/v1/api/openplatform/coding_plan/remains";
+const QUOTA_PATH = "/v1/token_plan/remains";
 
 function quotaUrl(region: Region): string {
   return REGIONS[region] + QUOTA_PATH;

--- a/test/auth/timeout-fix.test.ts
+++ b/test/auth/timeout-fix.test.ts
@@ -29,7 +29,7 @@ describe('detect-region: probeRegion auth style fallback', () => {
   it('succeeds when endpoint only accepts Bearer token', async () => {
     server = createMockServer({
       routes: {
-        '/v1/api/openplatform/coding_plan/remains': (req) => {
+        '/v1/token_plan/remains': (req) => {
           if (req.headers.get('Authorization') === 'Bearer bearer-only-key') {
             return jsonResponse({ base_resp: { status_code: 0 } });
           }
@@ -55,7 +55,7 @@ describe('detect-region: probeRegion auth style fallback', () => {
   it('succeeds when endpoint only accepts x-api-key header', async () => {
     server = createMockServer({
       routes: {
-        '/v1/api/openplatform/coding_plan/remains': (req) => {
+        '/v1/token_plan/remains': (req) => {
           if (req.headers.get('x-api-key') === 'xapikey-only-key') {
             return jsonResponse({ base_resp: { status_code: 0 } });
           }
@@ -80,7 +80,7 @@ describe('detect-region: probeRegion auth style fallback', () => {
   it('falls back to global when key is invalid for all auth styles and regions', async () => {
     server = createMockServer({
       routes: {
-        '/v1/api/openplatform/coding_plan/remains': () =>
+        '/v1/token_plan/remains': () =>
           jsonResponse({ error: 'unauthorized' }, 401),
       },
     });

--- a/test/client/endpoints.test.ts
+++ b/test/client/endpoints.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect } from 'bun:test';
 import { quotaEndpoint } from '../../src/client/endpoints';
 
 describe('quotaEndpoint', () => {
-  it('uses coding_plan/remains for global', () => {
-    expect(quotaEndpoint('https://api.minimax.io')).toBe('https://api.minimax.io/v1/api/openplatform/coding_plan/remains');
+  it('uses token_plan/remains for global', () => {
+    expect(quotaEndpoint('https://api.minimax.io')).toBe('https://api.minimax.io/v1/token_plan/remains');
   });
 
-  it('uses coding_plan/remains for cn', () => {
-    expect(quotaEndpoint('https://api.minimaxi.com')).toBe('https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains');
+  it('uses token_plan/remains for cn', () => {
+    expect(quotaEndpoint('https://api.minimaxi.com')).toBe('https://api.minimaxi.com/v1/token_plan/remains');
+  });
+
+  it('honors a custom base URL', () => {
+    expect(quotaEndpoint('https://gateway.example.com')).toBe('https://gateway.example.com/v1/token_plan/remains');
   });
 });

--- a/test/sdk/quota.test.ts
+++ b/test/sdk/quota.test.ts
@@ -4,7 +4,7 @@ import { MiniMaxSDK } from '../../src/sdk';
 describe('MiniMaxSDK.quota', () => {
   it('should get quota info successfully', async () => {
     const mockFetch = mock(async (url: string) => {
-      if (url.includes('/v1/api/openplatform/coding_plan/remains')) {
+      if (url.includes('/v1/token_plan/remains')) {
         return new Response(JSON.stringify({
           model_remains: [
             {


### PR DESCRIPTION
## What

`mmx quota show` (and region auto-detection) call a stale, hardcoded quota endpoint. Two problems in `quotaEndpoint()`:

```ts
export function quotaEndpoint(baseUrl: string): string {
  // Quota endpoint uses api subdomain
  const host = baseUrl.includes('minimaxi.com') ? 'https://api.minimaxi.com' : 'https://api.minimax.io';
  return `${host}/v1/api/openplatform/coding_plan/remains`;
}
```

1. **Ignores `baseUrl`** — it rebuilds the host from a `minimaxi.com` substring check instead of using the argument. It's the **only** endpoint in `endpoints.ts` that doesn't use the passed `baseUrl`, so `--base-url` / `MINIMAX_BASE_URL` / custom gateways are silently dropped for quota.
2. **Stale path** — `/v1/api/openplatform/coding_plan/remains`. The server now serves quota at **`/v1/token_plan/remains`** (consistent with the Token Plan naming). This file originally used `token_plan/remains`; it was changed to the openplatform path and that path now misbehaves.

### Evidence
With a line-matched API key (no OAuth needed):

| path | result |
|------|--------|
| `…/v1/api/openplatform/coding_plan/remains` | `1004 cookie is missing, log in again` |
| `…/v1/token_plan/remains` | ✅ `model_remains` returned |

Confirmed on **both** lines (`api.minimax.io` and `api.minimaxi.com`).

## Changes
- **`src/client/endpoints.ts`** — `return \`${baseUrl}/v1/token_plan/remains\``; drop the host rewrite. `REGIONS` base URLs are already `api.*` hosts, so no host fix-up is needed, and custom base URLs are now honored.
- **`src/config/detect-region.ts`** — region probe uses the same new path.
- **Tests** — update `endpoints` / `sdk/quota` / `auth/timeout-fix` expectations to the new path; add a test asserting a custom base URL is honored.

## Verification
- `bun test` — 356 pass / 0 fail
- `tsc --noEmit` clean
- Live `mmx quota show` on both lines renders the quota table; `--verbose` confirms `GET …/v1/token_plan/remains`.

## Scope
Independent of #173/#174 (those fix quota *rendering*); this fixes the quota *endpoint*. Branches off `main`.
