### PR TITLE
fix(quota): surface "not in plan" for 0/0 + status=3 models

### DIFF
--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -78,10 +78,29 @@ const COMPACT_BAR_WIDTH = 10;
 // at 200% to leave headroom and keep the bar/text readable.
 const MAX_DISPLAY_PCT = 200;
 
-// Weekly quota is unlimited when the server reports `current_weekly_status: 3`
-// (per the status enum: 1=normal, 2=exhausted, 3=unlimited).
-function isUnweekly(status: number | undefined | null): boolean {
-  return status === 3;
+// Server-side status enum: 1=normal (limited), 2=exhausted, 3=unlimited.
+//
+// Caveat: when `total_count === 0 && status === 3` the model is not in the
+// user's plan at all (the API conflates "no bucket" with "unlimited").
+// Callers must check `isNotInPlan` first; only treat status=3 as truly
+// unlimited when there is a real allowance bucket (total > 0).
+export function isUnweekly(
+  status: number | undefined | null,
+  totalCount: number,
+): boolean {
+  return status === 3 && totalCount > 0;
+}
+
+// Detect models whose status=3 actually means "not in your plan" rather
+// than unlimited. The signal is `total_count === 0 && status === 3`:
+// the server has no allowance bucket (count is zero) but still reports
+// status 3, which would otherwise render as "100% unlimited" — the very
+// inconsistency reported in #173.
+export function isNotInPlan(
+  totalCount: number,
+  status: number | undefined | null,
+): boolean {
+  return totalCount === 0 && status === 3;
 }
 
 function clampPct(value: number): number {
@@ -124,6 +143,8 @@ function renderBar(remainingPct: number, color: boolean, barWidth: number = BAR_
 const UNLIMITED_SYMBOL = '∞';
 const UNLIMITED_LABEL_CN = '无限';
 const UNLIMITED_LABEL_EN = 'unlimited';
+const NOT_IN_PLAN_LABEL_CN = '不在套餐中';
+const NOT_IN_PLAN_LABEL_EN = 'not in plan';
 
 function renderMetric(
   label: string,
@@ -134,7 +155,18 @@ function renderMetric(
   boostPermille?: number | null,
   unlimited?: boolean,
   unlimitedLabel?: string,
+  notInPlan?: boolean,
+  notInPlanLabel?: string,
 ): string {
+  if (notInPlan) {
+    const nip = notInPlanLabel ?? NOT_IN_PLAN_LABEL_EN;
+    if (color) {
+      const bar = `${BG_EMPTY}${' '.repeat(COMPACT_BAR_WIDTH)}${R}`;
+      return `${D}${label}${R} ${bar} ${D}${nip}${R}`;
+    }
+    const bar = `[${'.'.repeat(COMPACT_BAR_WIDTH)}]`;
+    return `${label} ${bar} ${nip}`;
+  }
   if (unlimited) {
     const ul = unlimitedLabel ?? UNLIMITED_SYMBOL;
     const ulStr = ul.padStart(4);
@@ -169,12 +201,20 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
 
   const rows = models.map((m) => {
     const displayName = displayModelName(m.model_name, config.region);
+    const notInPlanLabel = config.region === 'cn' ? NOT_IN_PLAN_LABEL_CN : NOT_IN_PLAN_LABEL_EN;
+    const intervalNotInPlan = isNotInPlan(m.current_interval_total_count, m.current_interval_status);
+    const weeklyNotInPlan = isNotInPlan(m.current_weekly_total_count, m.current_weekly_status);
     const current = renderMetric(
       L.current,
       m.current_interval_usage_count,
       m.current_interval_total_count,
       m.current_interval_remaining_percent,
       useColor,
+      undefined,
+      false,
+      undefined,
+      intervalNotInPlan,
+      notInPlanLabel,
     );
     const weekly = renderMetric(
       L.weekly,
@@ -183,8 +223,10 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
       m.current_weekly_remaining_percent,
       useColor,
       m.weekly_boost_permille,
-      isUnweekly(m.current_weekly_status),
+      isUnweekly(m.current_weekly_status, m.current_weekly_total_count),
       config.region === 'cn' ? UNLIMITED_LABEL_CN : UNLIMITED_LABEL_EN,
+      weeklyNotInPlan,
+      notInPlanLabel,
     );
     const reset = `${L.resetsIn} ${formatDuration(m.remains_time, L.now)}`;
     return { displayName, current, weekly, reset };

--- a/test/output/quota-table.test.ts
+++ b/test/output/quota-table.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'bun:test';
-import { renderQuotaTable } from '../../src/output/quota-table';
+import {
+  renderQuotaTable,
+  isNotInPlan,
+  isUnweekly,
+} from '../../src/output/quota-table';
 import type { Config } from '../../src/config/schema';
 import type { QuotaModelRemain } from '../../src/types/api';
 
@@ -189,7 +193,11 @@ describe('renderQuotaTable', () => {
     expect(output).not.toContain('300%');
   });
 
-  it('renders "无限" for weekly when status=3 (CN region)', () => {
+  // Behavior change for #173: when status=3 but total_count=0, the API is
+  // signalling "not in your plan" (a 0/0 bucket), not "unlimited". The CLI
+  // must surface this so users do not see "100% remaining" for a model
+  // they cannot actually use.
+  it('renders "不在套餐中" for weekly when status=3 + total_count=0 (CN region)', () => {
     const lines: string[] = [];
     const originalLog = console.log;
 
@@ -216,13 +224,13 @@ describe('renderQuotaTable', () => {
     }
 
     const output = lines.join('\n');
-    expect(output).toContain('[██████████]');
     expect(output).toContain('周剩余');
-    expect(output).toContain('无限');
+    expect(output).toContain('不在套餐中');
+    expect(output).not.toContain('无限');
     expect(output).not.toContain('150%');
   });
 
-  it('renders "unlimited" for weekly when status=3 (global region)', () => {
+  it('renders "not in plan" for weekly when status=3 + total_count=0 (global region)', () => {
     const lines: string[] = [];
     const originalLog = console.log;
 
@@ -248,9 +256,117 @@ describe('renderQuotaTable', () => {
     }
 
     const output = lines.join('\n');
-    expect(output).toContain('[██████████]');
+    expect(output).toContain('Wk left');
+    expect(output).toContain('not in plan');
+    expect(output).not.toContain('unlimited');
+    expect(output).not.toContain('100%');
+  });
+
+  it('still renders "unlimited" when status=3 + total_count > 0 (genuine unlimited)', () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(
+        [
+          {
+            ...createModel(),
+            current_weekly_total_count: 5000,
+            current_weekly_usage_count: 100,
+            current_weekly_remaining_percent: 98,
+            current_weekly_status: 3,
+          },
+        ],
+        { ...createConfig(), noColor: true },
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
     expect(output).toContain('Wk left');
     expect(output).toContain('unlimited');
+    expect(output).not.toContain('not in plan');
+  });
+
+  it('renders "not in plan" for interval (current) row when status=3 + total_count=0', () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(
+        [
+          {
+            ...createModel(),
+            model_name: 'video',
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 100,
+            current_weekly_status: 3,
+          },
+        ],
+        { ...createConfig(), noColor: true },
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    expect(output).toContain('Left');
+    expect(output).toContain('not in plan');
+    // The bug: previously this rendered "100%" via current_interval_remaining_percent.
     expect(output).not.toContain('100%');
+  });
+});
+
+describe('isNotInPlan', () => {
+  it('returns true when total_count is 0 and status is 3', () => {
+    expect(isNotInPlan(0, 3)).toBe(true);
+  });
+
+  it('returns false when total_count is positive (real unlimited)', () => {
+    expect(isNotInPlan(100, 3)).toBe(false);
+  });
+
+  it('returns false when status is not 3 (plain zero quota)', () => {
+    expect(isNotInPlan(0, 1)).toBe(false);
+    expect(isNotInPlan(0, 2)).toBe(false);
+  });
+
+  it('returns false when status is undefined or null', () => {
+    expect(isNotInPlan(0, undefined)).toBe(false);
+    expect(isNotInPlan(0, null)).toBe(false);
+  });
+});
+
+describe('isUnweekly', () => {
+  it('returns true only when status is 3 and total_count is positive', () => {
+    expect(isUnweekly(3, 100)).toBe(true);
+  });
+
+  it('returns false when total_count is 0 (would be not-in-plan)', () => {
+    expect(isUnweekly(3, 0)).toBe(false);
+  });
+
+  it('returns false when status is not 3', () => {
+    expect(isUnweekly(1, 100)).toBe(false);
+    expect(isUnweekly(2, 100)).toBe(false);
+  });
+
+  it('returns false when status is undefined or null', () => {
+    expect(isUnweekly(undefined, 100)).toBe(false);
+    expect(isUnweekly(null, 100)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Fix `mmx quota show` rendering "100% unlimited" for models that are not actually in the user's plan (e.g. `video` on Token Plan Plus).

Closes #173.

## Motivation
The quota API returns `total_count: 0, status: 3` for two semantically different states:
- "no allowance bucket" — the model is not bundled in the user's plan
- "unlimited" — the model has unlimited quota

The CLI previously rendered both as "100% unlimited". A Token Plan Plus user would see `video — 100% remaining`, then immediately get rejected by `/v1/video_generation` with `(0/0 used)` — the exact contradiction filed in #173.

## Changes
- New `isNotInPlan(total, status)` helper detecting the `total === 0 && status === 3` "no bucket" state.
- `isUnweekly(status, total)` tightened to require `total > 0`.
- `renderMetric` gains a `notInPlan` branch (empty bar + label), applied to both the `Left` (interval) and `Wk left` (weekly) columns.
- Labels: `not in plan` (en) / `不在套餐中` (cn).

No public API changes. No README changes required.

## Tests
`test/output/quota-table.test.ts` now has 16 passing tests:
- 4 unchanged regression tests
- 2 updated assertions that previously encoded the bug behaviour (asserted `unlimited` / `无限` for `total=0`)
- 3 new render-table tests covering the new "not in plan" path (interval column, weekly CN, weekly global) plus a regression test for the genuine unlimited path (`total > 0 + status=3`)
- 8 unit tests covering `isNotInPlan` and `isUnweekly`

Local verification:
- `bun test test/output/quota-table.test.ts` → 16 pass
- `bun test` → 370 pass / 2 fail. The 2 failures are pre-existing Windows-only `/dev/null` issues unrelated to this change (see #161).
- `bun run typecheck` → clean
- `bunx eslint src/output/quota-table.ts test/output/quota-table.test.ts` → clean

## Notes
- `isUnweekly` was previously not exported; the second `totalCount` parameter is additive. No existing call sites outside `quota-table.ts`.
- The decision to keep "unlimited" (when `total > 0`) is documented in source comments; future maintainers will see the rationale alongside the helper definitions.