### PR TITLE
fix file upload endpoint

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -43,7 +43,7 @@ export function quotaEndpoint(baseUrl: string): string {
 }
 
 export function fileUploadEndpoint(baseUrl: string): string {
-  return `${baseUrl}/v1/files`;
+  return `${baseUrl}/v1/files/upload`;
 }
 
 export function fileListEndpoint(baseUrl: string): string {

--- a/test/client/endpoints.test.ts
+++ b/test/client/endpoints.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { quotaEndpoint } from '../../src/client/endpoints';
+import { fileUploadEndpoint, quotaEndpoint } from '../../src/client/endpoints';
 
 describe('quotaEndpoint', () => {
   it('uses token_plan/remains for global', () => {
@@ -12,5 +12,11 @@ describe('quotaEndpoint', () => {
 
   it('honors a custom base URL', () => {
     expect(quotaEndpoint('https://gateway.example.com')).toBe('https://gateway.example.com/v1/token_plan/remains');
+  });
+});
+
+describe('fileUploadEndpoint', () => {
+  it('uses the documented file upload path', () => {
+    expect(fileUploadEndpoint('https://api.minimax.io')).toBe('https://api.minimax.io/v1/files/upload');
   });
 });


### PR DESCRIPTION
## Summary

Fix the MiniMax file upload endpoint used by `mmx file upload` and the File SDK.

The current endpoint is `/v1/files`, which returns 404 against the public API. The documented and working upload endpoint is `/v1/files/upload`.

## Changes

- Update `fileUploadEndpoint()` to use `/v1/files/upload`
- Add endpoint coverage for the file upload URL

## Verification

- `bun test test/client/endpoints.test.ts test/commands/file/upload.test.ts test/sdk/file.test.ts`
- `bun run typecheck`
- `bun run build`

## Notes

I verified the failure manually with `mmx file upload`, which POSTed to `/v1/files` and received a 404. Posting the same multipart form to `/v1/files/upload` succeeds and returns a `file.file_id`.