### PR TITLE
fix(speech): serialize pronunciation dictionary correctly

### DIFF
--- a/src/commands/speech/synthesize.ts
+++ b/src/commands/speech/synthesize.ts
@@ -92,10 +92,9 @@ export default defineCommand({
     if (flags.subtitles) body.subtitle_enable = true;  // Correct API parameter name
 
     if (flags.pronunciation) {
-      body.pronunciation_dict = (flags.pronunciation as string[]).map(p => {
-        const [from, to] = p.split('/');
-        return { tone: to || from!, text: from! };
-      });
+      body.pronunciation_dict = {
+        tone: flags.pronunciation as string[],
+      };
     }
 
     if (dryRun(config, body)) return;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -105,7 +105,7 @@ export interface SpeechRequest {
     channel?: number;
   };
   language_boost?: string;
-  pronunciation_dict?: Array<{ tone: string; text: string }>;
+  pronunciation_dict?: { tone: string[] };
   output_format?: 'url' | 'hex';
   stream?: boolean;
   subtitle_enable?: boolean;  // Correct API parameter name (not 'subtitle')

--- a/test/commands/speech/synthesize.test.ts
+++ b/test/commands/speech/synthesize.test.ts
@@ -202,6 +202,105 @@ describe('speech synthesize command', () => {
       console.log = originalLog;
     }
   });
+
+  it('--pronunciation serializes multiple values with the API-compatible shape', async () => {
+    const config = {
+      apiKey: 'test-key',
+      region: 'global' as const,
+      baseUrl: 'https://api.mmx.io',
+      output: 'json' as const,
+      timeout: 10,
+      verbose: false,
+      quiet: false,
+      noColor: true,
+      yes: false,
+      dryRun: true,
+      nonInteractive: true,
+      async: false,
+    };
+
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+
+    try {
+      await synthesizeCommand.execute(config, {
+        text: '处理这个危险的情况。',
+        pronunciation: [
+          '处理/(chu3)(li3)',
+          '危险/dangerous',
+        ],
+        quiet: false,
+        verbose: false,
+        noColor: true,
+        yes: false,
+        dryRun: true,
+        help: false,
+        nonInteractive: true,
+        async: false,
+      });
+
+      const parsed = JSON.parse(output);
+
+      // pronunciation_dict is an object with a tone string array — not the
+      // old array-of-{text,tone} shape — and each value is preserved verbatim
+      // (no splitting, trimming, or rewriting), covering both the pinyin form
+      // and the plain-replacement form shown in the official API docs.
+      expect(Array.isArray(parsed.request.pronunciation_dict)).toBe(false);
+      expect(parsed.request.pronunciation_dict).toEqual({
+        tone: [
+          '处理/(chu3)(li3)',
+          '危险/dangerous',
+        ],
+      });
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('--pronunciation with a single value serializes under tone', async () => {
+    const config = {
+      apiKey: 'test-key',
+      region: 'global' as const,
+      baseUrl: 'https://api.mmx.io',
+      output: 'json' as const,
+      timeout: 10,
+      verbose: false,
+      quiet: false,
+      noColor: true,
+      yes: false,
+      dryRun: true,
+      nonInteractive: true,
+      async: false,
+    };
+
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+
+    try {
+      await synthesizeCommand.execute(config, {
+        text: 'Omg, the real danger is not that computers start thinking.',
+        pronunciation: ['Omg/Oh my god'],
+        quiet: false,
+        verbose: false,
+        noColor: true,
+        yes: false,
+        dryRun: true,
+        help: false,
+        nonInteractive: true,
+        async: false,
+      });
+
+      const parsed = JSON.parse(output);
+
+      expect(parsed.request.pronunciation_dict).toEqual({
+        tone: ['Omg/Oh my god'],
+      });
+    } finally {
+      console.log = originalLog;
+    }
+  });
 });
 
 describe('speech synthesize format validation', () => {


### PR DESCRIPTION
## Summary

`mmx speech synthesize --pronunciation` built the wrong JSON shape for `pronunciation_dict`, so every request using the flag was rejected by the MiniMax T2A API (`/v1/t2a_v2`). Custom pronunciation — e.g. Chinese polyphonic characters (多音字) — was completely unusable from the CLI.

Fixes #187.

## Before

```json
"pronunciation_dict": [
  { "tone": "(chong2)", "text": "重" }
]
```

The CLI split each `word/(pronunciation)` value on `/` and rebuilt it as `{ tone, text }` inside an array.

## After

```json
"pronunciation_dict": {
  "tone": ["处理/(chu3)(li3)", "危险/dangerous"]
}
```

Each value is preserved verbatim inside a `tone` string array on an object, matching the official [`PronunciationDict` schema](https://platform.minimax.io/docs/api-reference/speech-t2a-http). Dry-run output matches the API-required `pronunciation_dict` shape. The payload shape is confirmed by the official API documentation and the reporter's raw API reproduction in #187.

## Root cause

Two places encoded the wrong shape:

- `src/types/api.ts` — `SpeechRequest.pronunciation_dict` was typed as `Array<{ tone: string; text: string }>`, describing an array of objects.
- `src/commands/speech/synthesize.ts` — the `--pronunciation` block split each value on `/` and rebuilt it as `{ tone: to, text: from }`, then wrapped the results in an array.

The API rejects the array form with `Mismatch type open_platform.PronunciationDict with value array`.

## Changes

- **`src/types/api.ts`** — `pronunciation_dict?: { tone: string[] }` to match the API contract.
- **`src/commands/speech/synthesize.ts`** — pass each `--pronunciation` value through verbatim into `body.pronunciation_dict = { tone: flags.pronunciation as string[] }` instead of splitting it. No CLI-side validation of pronunciation syntax — the MiniMax API is the source of truth for pronunciation syntax.
- **`test/commands/speech/synthesize.test.ts`** — 2 dry-run regression tests (see below).

The change is narrowly scoped to issue #187 — no unrelated refactors.

## SDK consumers

`SpeechRequest` is an exported type used by the public `SpeechSDK`. Any external code building the old `Array<{ tone; text }>` shape will get a compile-time type error after this change. That code was already broken at runtime (the API never accepted the array form), so this surfaces the break earlier — at compile time instead of at the API call. The SDK itself forwards `SpeechRequest` correctly via `toMerged` and requires no runtime changes. To migrate, pass `{ tone: ["word/(pronunciation)"] }`.

## Tests

Added 2 focused dry-run regression tests in `test/commands/speech/synthesize.test.ts`:

- `--pronunciation serializes multiple values with the API-compatible shape` — repeated `--pronunciation` values covering both the pinyin form (`处理/(chu3)(li3)`) and the plain-replacement form (`危险/dangerous`) shown in the official API docs. Asserts `pronunciation_dict` is an object with a `tone` string array (not the old array-of-objects shape) and that each value is preserved verbatim — no splitting, trimming, or rewriting.
- `--pronunciation with a single value serializes under tone` — single value (`Omg/Oh my god`, from the official API docs example).

## Verification

- `bun test test/commands/speech/synthesize.test.ts` — 20/20 pass (2 new)
- `bun run typecheck` — pass
- `bun run lint` — no new errors (2 pre-existing errors in unrelated test files on `upstream/main`)
- `bun test` — no new failures (40 pre-existing failures on `upstream/main` are unrelated to speech synthesis; +2 tests, +2 pass)
- `bun run build` — pass

## Reproduction

```bash
mmx speech synthesize \
  --text "我要去重庆出差。" \
  --pronunciation "重/(chong2)" \
  --out out.mp3
```

Before: `Error: API error: invalid params, Mismatch type open_platform.PronunciationDict with value array`
After: dry-run output matches the API-required `pronunciation_dict` shape.