### PR TITLE
fix(auth): document MMX_CONFIG_DIR in credential errors

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -15,7 +15,7 @@ This document lists all error scenarios and the messages users will see.
 | OAuth error in callback | `OAuth error: ${error}` |
 | OAuth token exchange failed | `OAuth token exchange failed: ${body}` |
 | `MINIMAX_API_KEY` already set (non-interactive) | `Warning: MINIMAX_API_KEY is already set in environment.` |
-| No credentials found (non-interactive) | `No credentials found.` + hint: `Log in: mmx auth login`, `--api-key sk-xxxxx`, or `MMX_CONFIG_DIR=/path/to/.mmx` |
+| No credentials found (non-interactive) | `No credentials found.` + the searched `config.json` path and hint: `Log in: mmx auth login`, `--api-key sk-xxxxx`, or `MMX_CONFIG_DIR=/path/to/.mmx` |
 
 ### `mmx auth logout`
 

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -15,6 +15,7 @@ This document lists all error scenarios and the messages users will see.
 | OAuth error in callback | `OAuth error: ${error}` |
 | OAuth token exchange failed | `OAuth token exchange failed: ${body}` |
 | `MINIMAX_API_KEY` already set (non-interactive) | `Warning: MINIMAX_API_KEY is already set in environment.` |
+| No credentials found (non-interactive) | `No credentials found.` + hint: `Log in: mmx auth login`, `--api-key sk-xxxxx`, or `MMX_CONFIG_DIR=/path/to/.mmx` |
 
 ### `mmx auth logout`
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ Useful for CI/CD (`mmx auth login --api-key sk-xxxxx`), or pass per-command via 
 OAuth and API key are mutually exclusive — logging in with one clears the other.
 Credential priority: `--api-key` flag > OAuth (config) > `api_key` (config).
 
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `MINIMAX_REGION` | `global` or `cn`. |
+| `MINIMAX_BASE_URL` | Override the API base URL. |
+| `MINIMAX_OUTPUT` | `text` or `json`. |
+| `MINIMAX_TIMEOUT` | Request timeout in seconds. |
+| `MINIMAX_VERBOSE` | `1` to enable verbose HTTP logging. |
+| `MMX_CONFIG_DIR` | Directory containing the `config.json` file (default: `~/.mmx`). Set this when `mmx` runs from a subprocess, service, or CI job whose home directory differs from where you logged in. |
+
 ### `mmx config` · `mmx quota`
 
 ```bash

--- a/src/auth/hints.ts
+++ b/src/auth/hints.ts
@@ -1,0 +1,11 @@
+import { getConfigPath } from '../config/paths';
+
+const NO_CREDENTIALS_REMEDIATION = [
+  'Log in:          mmx auth login',
+  'Pass per-call:   --api-key sk-xxxxx',
+  'Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx',
+].join('\n');
+
+export function buildNoCredentialsHint(configPath?: string): string {
+  return `Looked for credentials in: ${configPath ?? getConfigPath()}\n${NO_CREDENTIALS_REMEDIATION}`;
+}

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -4,6 +4,7 @@ import { loadCredentials } from './credentials';
 import { ensureFreshToken } from './refresh';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
+import { buildNoCredentialsHint } from './hints';
 
 export async function resolveCredential(config: Config): Promise<ResolvedCredential> {
   // 1. --api-key flag
@@ -26,8 +27,6 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
   throw new CLIError(
     'No credentials found.',
     ExitCode.AUTH,
-    'Log in:          mmx auth login\n' +
-      'Pass per-call:   --api-key sk-xxxxx\n' +
-      'Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx',
+    buildNoCredentialsHint(config.configPath),
   );
 }

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -26,6 +26,8 @@ export async function resolveCredential(config: Config): Promise<ResolvedCredent
   throw new CLIError(
     'No credentials found.',
     ExitCode.AUTH,
-    'Log in:        mmx auth login\nPass directly:  --api-key sk-xxxxx',
+    'Log in:          mmx auth login\n' +
+      'Pass per-call:   --api-key sk-xxxxx\n' +
+      'Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx',
   );
 }

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -46,7 +46,9 @@ export async function ensureAuth(config: Config): Promise<void> {
     throw new CLIError(
       'No credentials found.',
       ExitCode.AUTH,
-      'Log in:        mmx auth login\nPass directly:  --api-key sk-xxxxx',
+      'Log in:          mmx auth login\n' +
+        'Pass per-call:   --api-key sk-xxxxx\n' +
+        'Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx',
     );
   }
 

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -8,6 +8,7 @@ import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 import { deviceCodeLogin } from './oauth';
 import { loadCredentials } from './credentials';
+import { buildNoCredentialsHint } from './hints';
 
 interface AuthChoice {
   value: 'oauth-global' | 'oauth-cn' | 'api-key';
@@ -46,9 +47,7 @@ export async function ensureAuth(config: Config): Promise<void> {
     throw new CLIError(
       'No credentials found.',
       ExitCode.AUTH,
-      'Log in:          mmx auth login\n' +
-        'Pass per-call:   --api-key sk-xxxxx\n' +
-        'Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx',
+      buildNoCredentialsHint(config.configPath),
     );
   }
 

--- a/test/auth/resolver.test.ts
+++ b/test/auth/resolver.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { resolveCredential } from '../../src/auth/resolver';
+import { ensureAuth } from '../../src/auth/setup';
+import { CLIError } from '../../src/errors/base';
 import type { Config } from '../../src/config/schema';
 import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -59,9 +61,54 @@ describe('resolveCredential', () => {
     await expect(resolveCredential(config)).rejects.toThrow('No credentials found');
   });
 
+  it('no-credentials hint mentions MMX_CONFIG_DIR and working remediation options', async () => {
+    const config = makeConfig();
+    try {
+      await resolveCredential(config);
+      throw new Error('expected resolveCredential to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CLIError);
+      const hint = (err as CLIError).hint ?? '';
+      expect(hint).toContain('mmx auth login');
+      expect(hint).toContain('--api-key');
+      expect(hint).toContain('MMX_CONFIG_DIR');
+    }
+  });
+
   it('prefers flag over file api key', async () => {
     const config = makeConfig({ apiKey: 'sk-flag', fileApiKey: 'sk-file' });
     const cred = await resolveCredential(config);
     expect(cred.token).toBe('sk-flag');
+  });
+});
+
+describe('ensureAuth (non-interactive, no credentials)', () => {
+  const testDir = join(tmpdir(), `mmx-setup-test-${Date.now()}`);
+  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+
+  beforeEach(() => {
+    mkdirSync(join(testDir, '.mmx'), { recursive: true });
+    process.env.MMX_CONFIG_DIR = join(testDir, '.mmx');
+  });
+
+  afterEach(() => {
+    if (originalConfigDir) process.env.MMX_CONFIG_DIR = originalConfigDir;
+    else delete process.env.MMX_CONFIG_DIR;
+    delete process.env.MINIMAX_API_KEY;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('no-credentials hint mentions MMX_CONFIG_DIR and working remediation options', async () => {
+    const config = makeConfig({ nonInteractive: true });
+    try {
+      await ensureAuth(config);
+      throw new Error('expected ensureAuth to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CLIError);
+      const hint = (err as CLIError).hint ?? '';
+      expect(hint).toContain('mmx auth login');
+      expect(hint).toContain('--api-key');
+      expect(hint).toContain('MMX_CONFIG_DIR');
+    }
   });
 });

--- a/test/auth/resolver.test.ts
+++ b/test/auth/resolver.test.ts
@@ -26,18 +26,23 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
 
 describe('resolveCredential', () => {
   const testDir = join(tmpdir(), `mmx-resolver-test-${Date.now()}`);
-  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+  let originalConfigDir: string | undefined;
+  let originalApiKey: string | undefined;
 
   beforeEach(() => {
+    originalConfigDir = process.env.MMX_CONFIG_DIR;
+    originalApiKey = process.env.MINIMAX_API_KEY;
     const configDir = join(testDir, '.mmx');
     mkdirSync(configDir, { recursive: true });
     process.env.MMX_CONFIG_DIR = configDir;
+    delete process.env.MINIMAX_API_KEY;
   });
 
   afterEach(() => {
-    if (originalConfigDir) process.env.MMX_CONFIG_DIR = originalConfigDir;
+    if (originalConfigDir !== undefined) process.env.MMX_CONFIG_DIR = originalConfigDir;
     else delete process.env.MMX_CONFIG_DIR;
-    delete process.env.MINIMAX_API_KEY;
+    if (originalApiKey !== undefined) process.env.MINIMAX_API_KEY = originalApiKey;
+    else delete process.env.MINIMAX_API_KEY;
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -72,6 +77,7 @@ describe('resolveCredential', () => {
       expect(hint).toContain('mmx auth login');
       expect(hint).toContain('--api-key');
       expect(hint).toContain('MMX_CONFIG_DIR');
+      expect(hint).toContain(join(testDir, '.mmx', 'config.json'));
     }
   });
 
@@ -84,17 +90,22 @@ describe('resolveCredential', () => {
 
 describe('ensureAuth (non-interactive, no credentials)', () => {
   const testDir = join(tmpdir(), `mmx-setup-test-${Date.now()}`);
-  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+  let originalConfigDir: string | undefined;
+  let originalApiKey: string | undefined;
 
   beforeEach(() => {
+    originalConfigDir = process.env.MMX_CONFIG_DIR;
+    originalApiKey = process.env.MINIMAX_API_KEY;
     mkdirSync(join(testDir, '.mmx'), { recursive: true });
     process.env.MMX_CONFIG_DIR = join(testDir, '.mmx');
+    delete process.env.MINIMAX_API_KEY;
   });
 
   afterEach(() => {
-    if (originalConfigDir) process.env.MMX_CONFIG_DIR = originalConfigDir;
+    if (originalConfigDir !== undefined) process.env.MMX_CONFIG_DIR = originalConfigDir;
     else delete process.env.MMX_CONFIG_DIR;
-    delete process.env.MINIMAX_API_KEY;
+    if (originalApiKey !== undefined) process.env.MINIMAX_API_KEY = originalApiKey;
+    else delete process.env.MINIMAX_API_KEY;
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -109,6 +120,7 @@ describe('ensureAuth (non-interactive, no credentials)', () => {
       expect(hint).toContain('mmx auth login');
       expect(hint).toContain('--api-key');
       expect(hint).toContain('MMX_CONFIG_DIR');
+      expect(hint).toContain(join(testDir, '.mmx', 'config.json'));
     }
   });
 });


### PR DESCRIPTION
## Summary

Documents the existing `MMX_CONFIG_DIR` environment variable and includes it in the remediation guidance shown when the CLI cannot find credentials.

This helps users running `mmx` from agents, services, CI jobs, or subprocesses whose resolved home directory differs from the credential owner's — the exact scenario in #185, where `os.homedir()` returns a different path than where `~/.mmx/config.json` lives.

## Before

```
No credentials found.
hint: Log in:        mmx auth login
      Pass directly:  --api-key sk-xxxxx
```

The hint mentioned only two remediation options. `MMX_CONFIG_DIR` was functional but undocumented — users only discovered it by reading `src/config/paths.ts`.

## After

```
No credentials found.
hint: Looked for credentials in: /resolved/path/.mmx/config.json
      Log in:          mmx auth login
      Pass per-call:   --api-key sk-xxxxx
      Or set env var:  MMX_CONFIG_DIR=/path/to/.mmx
```

## Why MMX_CONFIG_DIR and not MINIMAX_API_KEY

`MMX_CONFIG_DIR` is a working remediation: it changes where the CLI looks for `config.json`, so credentials saved via `mmx auth login` are found even when `os.homedir()` differs.

`MINIMAX_API_KEY` is **not** listed in the hint because it does not work end-to-end. `ensureAuth()` in `src/auth/setup.ts` recognizes it and returns early, but the actual request path calls `resolveCredential()` in `src/auth/resolver.ts`, which never reads `process.env.MINIMAX_API_KEY` — it only checks `config.apiKey` (the `--api-key` flag), OAuth credentials, and `config.fileApiKey`. So a user setting `MINIMAX_API_KEY` would pass the setup gate but still get "No credentials found" when the first real request is made. Listing it as a remediation would be misleading.

This PR does not fix `MINIMAX_API_KEY` — that is a separate pre-existing issue tracked in #192 and outside the scope of #185. It only lists remediation options that genuinely work.

## Changes

- **`src/auth/hints.ts`** — centralize the shared no-credentials remediation and include the exact `config.json` path that was searched.
- **`src/auth/resolver.ts`** — use the shared hint for request-time credential resolution.
- **`src/auth/setup.ts`** — use the same hint on the non-interactive setup path.
- **`README.md`** — add an "Environment variables" section documenting the supported env vars, including `MMX_CONFIG_DIR` with guidance for subprocess/CI usage.
- **`ERRORS.md`** — add the previously-missing "No credentials found" row to the auth error reference.
- **`test/auth/resolver.test.ts`** — cover both error paths, assert the resolved config path, and isolate/restore `MMX_CONFIG_DIR` and `MINIMAX_API_KEY` so local developer environments cannot affect the tests.

## Scope

This does **not** change credential lookup behavior or attempt automatic cross-user credential discovery. It only makes the existing `MMX_CONFIG_DIR` override discoverable — the minimal Option A from the issue.

## Testing

- `bun test test/auth/resolver.test.ts` — 6/6 pass (2 new)
- `bun run typecheck` — pass
- `bun run lint` — no new errors (2 pre-existing errors in unrelated test files on `upstream/main`)
- `bun test` — no new failures (40 pre-existing failures on `upstream/main` are unrelated to auth; +2 tests, +2 pass)
- `bun run build` — pass

## Reproduction

```bash
# From a subprocess whose HOME differs from where you ran `mmx auth login`:
HOME=/tmp/nonexistent mmx quota show --output json
# Before: hint only mentions mmx auth login / --api-key
# After: hint also mentions MMX_CONFIG_DIR
```

Fixes #185