### PR TITLE
fix: mask API key output and clear conflicting OAuth credentials

### DIFF
--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -3,6 +3,7 @@ import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { readConfigFile, writeConfigFile } from '../../config/loader';
+import { maskToken } from '../../utils/token';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 
@@ -15,6 +16,10 @@ const KEY_ALIASES: Record<string, string> = {
   'default-video-model': 'default_video_model',
   'default-music-model': 'default_music_model',
 };
+
+function valueForOutput(key: string, value: unknown): unknown {
+  return key === 'api_key' ? maskToken(String(value)) : value;
+}
 
 export default defineCommand({
   name: 'config set',
@@ -49,6 +54,14 @@ export default defineCommand({
     if (!VALID_KEYS.includes(resolvedKey)) {
       throw new CLIError(
         `Invalid config key "${key}". Valid keys: ${VALID_KEYS.join(', ')}`,
+        ExitCode.USAGE,
+      );
+    }
+
+    const valueToSet = resolvedKey === 'api_key' ? value.trim() : value;
+    if (resolvedKey === 'api_key' && valueToSet.length === 0) {
+      throw new CLIError(
+        'Invalid api_key. The value must not be empty.',
         ExitCode.USAGE,
       );
     }
@@ -95,22 +108,28 @@ export default defineCommand({
     const format = detectOutputFormat(config.output);
 
     if (config.dryRun) {
-      console.log(formatOutput({ would_set: { [resolvedKey]: value } }, format));
+      console.log(formatOutput({
+        would_set: { [resolvedKey]: valueForOutput(resolvedKey, valueToSet) },
+      }, format));
       return;
     }
 
     const existing = readConfigFile() as Record<string, unknown>;
-    existing[resolvedKey] = resolvedKey === 'timeout' ? Number(value) : value;
+    existing[resolvedKey] = resolvedKey === 'timeout' ? Number(valueToSet) : valueToSet;
 
-    // When API key changes, clear cached region so it gets re-detected
+    // API key and OAuth are mutually exclusive. Clear OAuth and the cached
+    // region so subsequent requests resolve the new key and re-detect its host.
     if (resolvedKey === 'api_key') {
+      delete existing.oauth;
       delete existing.region;
     }
 
     await writeConfigFile(existing);
 
     if (!config.quiet) {
-      console.log(formatOutput({ [resolvedKey]: existing[resolvedKey] }, format));
+      console.log(formatOutput({
+        [resolvedKey]: valueForOutput(resolvedKey, existing[resolvedKey]),
+      }, format));
     }
   },
 });

--- a/test/commands/config/set.test.ts
+++ b/test/commands/config/set.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import { default as setCommand } from '../../../src/commands/config/set';
+import * as configLoader from '../../../src/config/loader';
 
 describe('config set command', () => {
   it('has correct name', () => {
@@ -128,5 +129,141 @@ describe('config set command', () => {
         async: false,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it('masks api_key in dry-run output', async () => {
+    const apiKey = 'sk-test-secret-123456';
+    const writeConfigFile = spyOn(configLoader, 'writeConfigFile').mockResolvedValue();
+    let output = '';
+    const originalLog = console.log;
+    console.log = (message: string) => { output += message; };
+
+    try {
+      await setCommand.execute({
+        region: 'global',
+        baseUrl: 'https://api.mmx.io',
+        output: 'json',
+        timeout: 10,
+        verbose: false,
+        quiet: false,
+        noColor: true,
+        yes: false,
+        dryRun: true,
+        nonInteractive: true,
+        async: false,
+      }, {
+        key: 'api_key',
+        value: apiKey,
+        quiet: false,
+        verbose: false,
+        noColor: true,
+        yes: false,
+        dryRun: true,
+        help: false,
+        nonInteractive: true,
+        async: false,
+      });
+    } finally {
+      console.log = originalLog;
+      writeConfigFile.mockRestore();
+    }
+
+    expect(output).not.toContain(apiKey);
+    expect(JSON.parse(output).would_set.api_key).toBe('sk-t...3456');
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it('removes OAuth and masks output when setting api_key', async () => {
+    const apiKey = 'sk-test-secret-123456';
+    const readConfigFile = spyOn(configLoader, 'readConfigFile').mockReturnValue({
+      region: 'cn',
+      oauth: {
+        access_token: 'old-access-token',
+        refresh_token: 'old-refresh-token',
+        expires_at: '2099-01-01T00:00:00.000Z',
+      },
+    });
+    let writtenConfig: Record<string, unknown> | undefined;
+    const writeConfigFile = spyOn(configLoader, 'writeConfigFile').mockImplementation(async (data) => {
+      writtenConfig = { ...data };
+    });
+    let output = '';
+    const originalLog = console.log;
+    console.log = (message: string) => { output += message; };
+
+    try {
+      await setCommand.execute({
+        region: 'cn',
+        baseUrl: 'https://api.mmx.io',
+        output: 'json',
+        timeout: 10,
+        verbose: false,
+        quiet: false,
+        noColor: true,
+        yes: false,
+        dryRun: false,
+        nonInteractive: true,
+        async: false,
+      }, {
+        key: 'api_key',
+        value: `  ${apiKey}  `,
+        quiet: false,
+        verbose: false,
+        noColor: true,
+        yes: false,
+        dryRun: false,
+        help: false,
+        nonInteractive: true,
+        async: false,
+      });
+    } finally {
+      console.log = originalLog;
+      readConfigFile.mockRestore();
+      writeConfigFile.mockRestore();
+    }
+
+    expect(writtenConfig).toEqual({ api_key: apiKey });
+    expect(output).not.toContain(apiKey);
+    expect(JSON.parse(output).api_key).toBe('sk-t...3456');
+  });
+
+  it('rejects empty api_key values without changing existing credentials', async () => {
+    const readConfigFile = spyOn(configLoader, 'readConfigFile');
+    const writeConfigFile = spyOn(configLoader, 'writeConfigFile').mockResolvedValue();
+
+    try {
+      for (const value of ['', '   ']) {
+        await expect(setCommand.execute({
+          region: 'cn',
+          baseUrl: 'https://api.mmx.io',
+          output: 'json',
+          timeout: 10,
+          verbose: false,
+          quiet: false,
+          noColor: true,
+          yes: false,
+          dryRun: false,
+          nonInteractive: true,
+          async: false,
+        }, {
+          key: 'api_key',
+          value,
+          quiet: false,
+          verbose: false,
+          noColor: true,
+          yes: false,
+          dryRun: false,
+          help: false,
+          nonInteractive: true,
+          async: false,
+        })).rejects.toThrow('must not be empty');
+      }
+    } finally {
+      readConfigFile.mockRestore();
+      writeConfigFile.mockRestore();
+    }
+
+    expect(readConfigFile).not.toHaveBeenCalled();
+    expect(writeConfigFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- mask `api_key` in normal and dry-run `config set` output
- remove an existing OAuth block when a new API key is stored
- clear the cached region so the new key is detected against the correct host
- reject empty or whitespace-only API keys before reading or writing configuration
- keep config command tests isolated so they do not replace the loader for auth tests

## Root cause

`config set` rendered every value verbatim, including API keys. It also wrote a new `api_key` without clearing OAuth, while the credential resolver prefers OAuth over the config-file API key. The command could therefore leak the secret and then silently continue using the old credential.

The first regression tests used a process-wide Bun module mock. After PR #194 added auth persistence coverage, that mock leaked into the auth tests and replaced their real temporary config loader. Empty values also remained valid and could erase a working OAuth session while saving an unusable key.

## Impact

The complete key is still written to the mode-0600 config file, but terminal and CI output only receive a masked value. A successful API-key update now leaves one unambiguous credential source. Empty values fail without touching existing credentials, and the tests preserve the isolation introduced by PR #194.

## Validation

- `bun test` — 392 passed
- targeted config and auth tests — 18 passed
- `bun run typecheck`
- `bun run build:dev`
- ESLint on all changed TypeScript files
- `git diff --check`
