### PR TITLE
chore: bump version to 1.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump package version from 1.0.16 to 1.0.17

## Verification
- bun run build
- bun run typecheck
- bun run lint (passes with existing 4 no-explicit-any warnings in tests)
- bun test
- node dist/mmx.mjs --version => mmx 1.0.17

## Live smoke testing
- auth status/config show/quota/search/text/speech/image/vision/file/video exercised with local ~/.mmx credentials
- music intentionally excluded from the final requested smoke scope
