### PR TITLE
fix: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "1.0.17",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MiniMax-AI/cli.git"
+  },
+  "homepage": "https://github.com/MiniMax-AI/cli#readme",
+  "bugs": {
+    "url": "https://github.com/MiniMax-AI/cli/issues"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- Add repository metadata to package.json
- Add homepage and bugs URLs so npm/security tooling can link the package back to GitHub

Closes #190

## Verification
- node -e "const p=require('./package.json'); console.log(p.repository, p.homepage, p.bugs)"
- bun run build
- bun run typecheck
- bun run lint (passes with existing 2 no-explicit-any warnings in tests)
- bun test
