### PR TITLE
release: v1.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mmx quota
 
 ```bash
 mmx text chat --message "Write a poem"
-mmx text chat --model MiniMax-M2.7-highspeed --message "Hello" --stream
+mmx text chat --model MiniMax-M3 --message "Hello" --stream
 mmx text chat --system "You are a coding assistant" --message "Fizzbuzz in Go"
 mmx text chat --message "user:Hi" --message "assistant:Hey!" --message "How are you?"
 cat messages.json | mmx text chat --messages-file - --output json
@@ -175,7 +175,7 @@ Credential priority: `--api-key` flag > OAuth (config) > `api_key` (config).
 mmx quota
 mmx config show
 mmx config set --key region --value cn
-mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
+mmx config set --key default-text-model --value MiniMax-M3
 mmx config export-schema | jq .
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@ mmx quota
 
 ```bash
 mmx text chat --message "写一首诗"
-mmx text chat --model MiniMax-M2.7-highspeed --message "你好" --stream
+mmx text chat --model MiniMax-M3 --message "你好" --stream
 mmx text chat --system "你是编程助手" --message "用 Go 写 Fizzbuzz"
 mmx text chat --message "user:你好" --message "assistant:嗨！" --message "你叫什么名字？"
 cat messages.json | mmx text chat --messages-file - --output json
@@ -156,7 +156,7 @@ Global 与中国两个 region，选用能通过的那个。
 mmx quota
 mmx config show
 mmx config set --key region --value cn
-mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
+mmx config set --key default-text-model --value MiniMax-M3
 mmx config export-schema | jq .
 ```
 

--- a/SDK.md
+++ b/SDK.md
@@ -27,14 +27,14 @@ You can also omit `apiKey` if it's already configured via `mmx config set api-ke
 
 ```typescript
 const response = await sdk.text.chat({
-  model: 'MiniMax-M2.7',
+  model: 'MiniMax-M3',
   messages: [{ role: 'user', content: 'Hello!' }],
   max_tokens: 4096,
 });
 
 // Streaming
 const stream = await sdk.text.chat({
-  model: 'MiniMax-M2.7',
+  model: 'MiniMax-M3',
   messages: [{ role: 'user', content: 'Write a poem' }],
   stream: true,
 });
@@ -109,7 +109,7 @@ const englishVoices = await sdk.speech.voices('en');
 
 ```typescript
 const music = await sdk.music.generate({
-  model: 'music-2.6',
+  model: 'music-3.0',
   prompt: 'Upbeat pop song',
   lyrics: '[verse] La da dee, sunny day',
   output_format: 'hex',

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -18,7 +18,7 @@ mmx
 │   ├── refresh            Manually refresh OAuth token
 │   └── logout             Revoke tokens and clear stored credentials
 ├── text
-│   └── chat               Send a chat completion (M2.7 / M2.7-highspeed)
+│   └── chat               Send a chat completion (M3)
 ├── speech
 │   └── synthesize         Synchronous TTS, ≤10k chars
 ├── image
@@ -29,7 +29,7 @@ mmx
 │   │   └── get            Query video task status
 │   └── download           Download a completed video by file ID
 ├── music
-│   └── generate           Generate a song (music-2.5)
+│   └── generate           Generate a song (music-3.0)
 ├── quota
 │   └── show               Display Token Plan usage and remaining quotas
 └── config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.5",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mmx-cli",
-      "version": "1.0.5",
+      "version": "1.0.18",
       "dependencies": {
         "@clack/prompts": "^0.7.0",
         "yaml": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmx-cli",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "CLI for the MiniMax AI Platform",
   "type": "module",
   "repository": {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -46,7 +46,7 @@ Always use these flags in non-interactive (agent/CI) contexts:
 
 ### text chat
 
-Chat completion. Default model: `MiniMax-M2.7`.
+Chat completion. Default model: `MiniMax-M3`.
 
 ```bash
 mmx text chat --message <text> [flags]
@@ -57,7 +57,7 @@ mmx text chat --message <text> [flags]
 | `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
 | `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
 | `--system <text>` | string | System prompt |
-| `--model <model>` | string | Model ID (default: `MiniMax-M2.7`) |
+| `--model <model>` | string | Model ID (default: `MiniMax-M3`) |
 | `--max-tokens <n>` | number | Max tokens (default: 4096) |
 | `--temperature <n>` | number | Sampling temperature (0.0, 1.0] |
 | `--top-p <n>` | number | Nucleus sampling threshold |
@@ -206,7 +206,7 @@ echo "Breaking news." | mmx speech synthesize --text-file - --out news.mp3
 
 Generate music. Responds well to rich, structured descriptions.
 
-**Model:** `music-2.6-free` — unlimited for API key users, RPM = 3.
+**Model:** `music-3.0` — default model.
 
 ```bash
 mmx music generate --prompt <text> [--lyrics <text>] [flags]
@@ -422,10 +422,10 @@ Set per-modality defaults so you don't need `--model` every time:
 
 ```bash
 # Set defaults
-mmx config set --key default-text-model --value MiniMax-M2.7-highspeed
+mmx config set --key default-text-model --value MiniMax-M3
 mmx config set --key default-speech-model --value speech-2.8-hd
 mmx config set --key default-video-model --value MiniMax-Hailuo-2.3
-mmx config set --key default-music-model --value music-2.6
+mmx config set --key default-music-model --value music-3.0
 
 # Use without --model
 mmx text chat --message "Hello"
@@ -434,7 +434,7 @@ mmx video generate --prompt "Ocean waves"
 mmx music generate --prompt "Upbeat pop" --instrumental
 
 # --model still overrides per-call
-mmx text chat --model MiniMax-M2.7 --message "Hello"
+mmx text chat --model MiniMax-M3 --message "Hello"
 ```
 
 **Resolution priority**: `--model` flag > config default > hardcoded fallback.

--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -109,7 +109,7 @@ export default defineCommand({
       );
     }
 
-    // Build structured prompt from optional music characteristic flags.
+    // Build structured prompt from optional music characteristic flags before request assembly.
     const structuredParts: string[] = [];
     if (flags.vocals)      structuredParts.push(`Vocals: ${flags.vocals as string}`);
     if (flags.genre)       structuredParts.push(`Genre: ${flags.genre as string}`);

--- a/src/commands/music/generate.ts
+++ b/src/commands/music/generate.ts
@@ -15,7 +15,7 @@ import { MUSIC_GENERATE_MODELS, musicGenerateModel } from './models';
 
 export default defineCommand({
   name: 'music generate',
-  description: 'Generate a song (music-2.6, including free tier)',
+  description: 'Generate a song (music-3.0)',
   apiDocs: '/docs/api-reference/music-generation',
   usage: 'mmx music generate --prompt <text> (--lyrics <text> | --instrumental | --lyrics-optimizer) [--out <path>] [flags]',
   options: [
@@ -36,7 +36,7 @@ export default defineCommand({
     { flag: '--structure <text>', description: 'Song structure, e.g. "verse-chorus-verse-bridge-chorus"' },
     { flag: '--references <text>', description: 'Reference tracks or artists, e.g. "similar to Ed Sheeran"' },
     { flag: '--extra <text>', description: 'Additional fine-grained requirements not covered above' },
-    { flag: '--model <model>', description: 'Model: music-2.6 (default), music-2.6-free, music-2.5+, or music-2.5.' },
+    { flag: '--model <model>', description: 'Model: music-3.0 (default), music-2.6, music-2.6-free, music-2.5+, or music-2.5.' },
     { flag: '--output-format <fmt>', description: 'Return format: hex (default, saved to file) or url (24h expiry, download promptly). When --stream, only hex.' },
     { flag: '--aigc-watermark', description: 'Embed AI-generated content watermark in audio for content provenance' },
     { flag: '--format <fmt>', description: `Audio format: ${formatList(MUSIC_FORMATS)} (default: mp3)` },
@@ -54,8 +54,8 @@ export default defineCommand({
     'mmx music generate --prompt "Cinematic orchestral, building tension" --instrumental --out bgm.mp3',
     '# URL output (24h expiry — download promptly):',
     'mmx music generate --prompt "Upbeat pop" --lyrics "La la la..." --output-format url',
-    '# Instrumental with music-2.5+:',
-    'mmx music generate --prompt "Cinematic orchestral" --model "music-2.5+" --instrumental --out bgm.mp3',
+    '# Instrumental with music-3.0:',
+    'mmx music generate --prompt "Cinematic orchestral" --model "music-3.0" --instrumental --out bgm.mp3',
     '# Detailed prompt with vocal characteristics:',
     'mmx music generate --prompt "Warm morning folk" --vocals "male and female duet, harmonies in chorus" --instruments "acoustic guitar, piano" --bpm 95 --lyrics-file song.txt --out duet.mp3',
   ],
@@ -139,7 +139,7 @@ export default defineCommand({
       throw new CLIError(
         `Invalid model "${model}". Valid models: ${MUSIC_GENERATE_MODELS.join(', ')}`,
         ExitCode.USAGE,
-        'mmx music generate --model music-2.6',
+        'mmx music generate --model music-3.0',
       );
     }
     const outFormat = (flags.outputFormat as string) || 'hex';

--- a/src/commands/music/models.ts
+++ b/src/commands/music/models.ts
@@ -1,6 +1,7 @@
 import type { Config } from '../../config/schema';
 
 export const MUSIC_GENERATE_MODELS = [
+  'music-3.0',
   'music-2.6',
   'music-2.6-free',
   'music-2.5+',
@@ -20,7 +21,7 @@ export function musicGenerateModel(config: Config): string {
   ) {
     return config.defaultMusicModel;
   }
-  return 'music-2.6';
+  return 'music-3.0';
 }
 
 export function musicCoverModel(config: Config): string {

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -159,7 +159,7 @@ export default defineCommand({
   apiDocs: '/docs/api-reference/text-post',
   usage: 'mmx text chat --message <text> [flags]',
   options: [
-    { flag: '--model <model>', description: 'Model ID (default: MiniMax-M2.7)' },
+    { flag: '--model <model>', description: 'Model ID (default: MiniMax-M3)' },
     { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role)', required: true, type: 'array' },
     { flag: '--messages-file <path>',  description: 'JSON file with messages array (use - for stdin)' },
     { flag: '--system <text>',         description: 'System prompt' },
@@ -171,7 +171,7 @@ export default defineCommand({
   ],
   examples: [
     'mmx text chat --message "What is MiniMax?"',
-    'mmx text chat --model MiniMax-M2.7-highspeed --system "You are a coding assistant." --message "Write fizzbuzz in Python"',
+    'mmx text chat --model MiniMax-M3 --system "You are a coding assistant." --message "Write fizzbuzz in Python"',
     'mmx text chat --message "Hello" --message "assistant:Hi!" --message "How are you?"',
     'cat conversation.json | mmx text chat --messages-file - --stream',
     'mmx text chat --message "Hello" --output json',
@@ -197,7 +197,7 @@ export default defineCommand({
 
     const model = (flags.model as string)
       || config.defaultTextModel
-      || 'MiniMax-M2.7';
+      || 'MiniMax-M3';
     const format = detectOutputFormat(config.output);
     const shouldStream = flags.stream === true || (
       flags.stream === undefined

--- a/src/commands/text/repl.ts
+++ b/src/commands/text/repl.ts
@@ -294,7 +294,7 @@ export default defineCommand({
   description: 'Start an interactive multi-turn chat session',
   usage: 'mmx text repl [flags]',
   options: [
-    { flag: '--model <model>',     description: 'Model ID (default: MiniMax-M2.7)' },
+    { flag: '--model <model>',     description: 'Model ID (default: MiniMax-M3)' },
     { flag: '--system <text>',     description: 'System prompt' },
     { flag: '--max-tokens <n>',    description: 'Maximum tokens per response (default: 4096)', type: 'number' },
     { flag: '--temperature <n>',   description: 'Sampling temperature (0.0, 1.0]', type: 'number' },
@@ -302,7 +302,7 @@ export default defineCommand({
   ],
   examples: [
     'mmx text repl',
-    'mmx text repl --model MiniMax-M2.7-highspeed --system "You are a coding assistant."',
+    'mmx text repl --model MiniMax-M3 --system "You are a coding assistant."',
     'mmx text repl --temperature 0.7 --max-tokens 8192',
   ],
   async run(config: Config, flags: GlobalFlags) {
@@ -325,7 +325,7 @@ export default defineCommand({
     const state: ReplState = {
       messages: [],
       system: flags.system as string | undefined,
-      model: (flags.model as string) || config.defaultTextModel || 'MiniMax-M2.7',
+      model: (flags.model as string) || config.defaultTextModel || 'MiniMax-M3',
       maxTokens: (flags.maxTokens as number) ?? 4096,
       temperature: flags.temperature !== undefined ? flags.temperature as number : undefined,
       topP: flags.topP !== undefined ? flags.topP as number : undefined,

--- a/src/sdk/text/index.ts
+++ b/src/sdk/text/index.ts
@@ -56,7 +56,7 @@ export class TextSDK extends Client {
 
     return {
       ...params,
-      model: params.model ?? 'MiniMax-M2.7',
+      model: params.model ?? 'MiniMax-M3',
       max_tokens: params.max_tokens ?? 4096,
     } as ChatRequest;
   }

--- a/test/commands/config/set.test.ts
+++ b/test/commands/config/set.test.ts
@@ -86,7 +86,7 @@ describe('config set command', () => {
     await expect(
       setCommand.execute(config, {
         key: 'default_text_model',
-        value: 'MiniMax-M2.7-highspeed',
+        value: 'MiniMax-M3',
         quiet: false,
         verbose: false,
         noColor: true,
@@ -118,7 +118,7 @@ describe('config set command', () => {
     await expect(
       setCommand.execute(config, {
         key: 'default-text-model',
-        value: 'MiniMax-M2.7-highspeed',
+        value: 'MiniMax-M3',
         quiet: false,
         verbose: false,
         noColor: true,

--- a/test/commands/config/show.test.ts
+++ b/test/commands/config/show.test.ts
@@ -4,10 +4,10 @@ import * as configLoader from '../../../src/config/loader';
 
 const CONFIG_FILE = {
   api_key: 'sk-cp-test-key',
-  default_text_model: 'MiniMax-M2.7-highspeed',
+  default_text_model: 'MiniMax-M3',
   default_speech_model: 'speech-2.8-hd',
   default_video_model: 'MiniMax-Hailuo-2.3-6s-768p',
-  default_music_model: 'music-2.6',
+  default_music_model: 'music-3.0',
 };
 
 describe('config show command', () => {
@@ -90,10 +90,10 @@ describe('config show command', () => {
       });
 
       const parsed = JSON.parse(output);
-      expect(parsed.default_text_model).toBe('MiniMax-M2.7-highspeed');
+      expect(parsed.default_text_model).toBe('MiniMax-M3');
       expect(parsed.default_speech_model).toBe('speech-2.8-hd');
       expect(parsed.default_video_model).toBe('MiniMax-Hailuo-2.3-6s-768p');
-      expect(parsed.default_music_model).toBe('music-2.6');
+      expect(parsed.default_music_model).toBe('music-3.0');
     } finally {
       console.log = originalLog;
       readConfigFile.mockRestore();

--- a/test/commands/music/generate.test.ts
+++ b/test/commands/music/generate.test.ts
@@ -161,7 +161,7 @@ describe('music generate command', () => {
 
     try {
       await generateCommand.execute(
-        { ...baseConfig, dryRun: true, output: 'json' as const, defaultMusicModel: 'music-2.6' },
+        { ...baseConfig, dryRun: true, output: 'json' as const, defaultMusicModel: 'music-3.0' },
         { ...baseFlags, dryRun: true, prompt: 'Folk', lyrics: 'no lyrics' },
       );
     } catch {
@@ -170,7 +170,7 @@ describe('music generate command', () => {
 
     console.log = origLog;
     const parsed = JSON.parse(captured);
-    expect(parsed.request.model).toBe('music-2.6');
+    expect(parsed.request.model).toBe('music-3.0');
   });
 
   it('--model flag overrides defaultMusicModel', async () => {
@@ -180,7 +180,7 @@ describe('music generate command', () => {
 
     try {
       await generateCommand.execute(
-        { ...baseConfig, dryRun: true, output: 'json' as const, defaultMusicModel: 'music-2.6' },
+        { ...baseConfig, dryRun: true, output: 'json' as const, defaultMusicModel: 'music-3.0' },
         { ...baseFlags, dryRun: true, prompt: 'Folk', lyrics: 'no lyrics', model: 'music-2.5' },
       );
     } catch {
@@ -192,7 +192,7 @@ describe('music generate command', () => {
     expect(parsed.request.model).toBe('music-2.5');
   });
 
-  it('accepts the official music-2.6-free model', async () => {
+  it('accepts the official music-3.0 model', async () => {
     let captured = '';
     const origLog = console.log;
     console.log = (msg: string) => { captured += msg; };
@@ -205,14 +205,14 @@ describe('music generate command', () => {
           dryRun: true,
           prompt: 'Folk',
           lyrics: 'la la',
-          model: 'music-2.6-free',
+          model: 'music-3.0',
         },
       );
     } finally {
       console.log = origLog;
     }
 
-    expect(JSON.parse(captured).request.model).toBe('music-2.6-free');
+    expect(JSON.parse(captured).request.model).toBe('music-3.0');
   });
 
   it('requires prompt for instrumental generation', async () => {

--- a/test/commands/music/models.test.ts
+++ b/test/commands/music/models.test.ts
@@ -4,12 +4,12 @@ import type { Config } from '../../../src/config/schema';
 
 describe('music models', () => {
   it('musicGenerateModel uses defaultMusicModel when set', () => {
-    const config = { defaultMusicModel: 'music-2.5+' } as Config;
-    expect(musicGenerateModel(config)).toBe('music-2.5+');
+    const config = { defaultMusicModel: 'music-3.0' } as Config;
+    expect(musicGenerateModel(config)).toBe('music-3.0');
   });
 
-  it('musicGenerateModel defaults to music-2.6', () => {
-    expect(musicGenerateModel({} as Config)).toBe('music-2.6');
+  it('musicGenerateModel defaults to music-3.0', () => {
+    expect(musicGenerateModel({} as Config)).toBe('music-3.0');
   });
 
   it('musicGenerateModel accepts the free-tier model', () => {
@@ -18,7 +18,7 @@ describe('music models', () => {
   });
 
   it('musicCoverModel ignores defaultMusicModel for non-cover models', () => {
-    const config = { defaultMusicModel: 'music-2.6' } as Config;
+    const config = { defaultMusicModel: 'music-3.0' } as Config;
     expect(musicCoverModel(config)).toBe('music-cover');
   });
 

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -96,7 +96,7 @@ describe('text chat command', () => {
       });
 
       const parsed = JSON.parse(output);
-      expect(parsed.request.model).toBe('MiniMax-M2.7');
+      expect(parsed.request.model).toBe('MiniMax-M3');
       expect(parsed.request.messages).toHaveLength(1);
     } finally {
       console.log = originalLog;
@@ -112,7 +112,7 @@ describe('text chat command', () => {
       baseUrl: 'https://api.mmx.io',
       output: 'json',
       timeout: 10,
-      defaultTextModel: 'MiniMax-M2.7-highspeed',
+      defaultTextModel: 'MiniMax-M3',
       verbose: false,
       quiet: false,
       noColor: true,
@@ -140,7 +140,7 @@ describe('text chat command', () => {
       });
 
       const parsed = JSON.parse(output);
-      expect(parsed.request.model).toBe('MiniMax-M2.7-highspeed');
+      expect(parsed.request.model).toBe('MiniMax-M3');
     } finally {
       console.log = originalLog;
     }
@@ -268,7 +268,7 @@ describe('text chat command', () => {
       baseUrl: 'https://api.mmx.io',
       output: 'json',
       timeout: 10,
-      defaultTextModel: 'MiniMax-M2.7-highspeed',
+      defaultTextModel: 'MiniMax-M3',
       verbose: false,
       quiet: false,
       noColor: true,

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -87,15 +87,15 @@ describe('parseConfigFile', () => {
 
   it('parses default model settings', () => {
     const cfg = parseConfigFile({
-      default_text_model: 'MiniMax-M2.7',
+      default_text_model: 'MiniMax-M3',
       default_speech_model: 'speech-2.8-hd',
       default_video_model: 'MiniMax-Hailuo-2.3',
-      default_music_model: 'music-2.6',
+      default_music_model: 'music-3.0',
     });
-    expect(cfg.default_text_model).toBe('MiniMax-M2.7');
+    expect(cfg.default_text_model).toBe('MiniMax-M3');
     expect(cfg.default_speech_model).toBe('speech-2.8-hd');
     expect(cfg.default_video_model).toBe('MiniMax-Hailuo-2.3');
-    expect(cfg.default_music_model).toBe('music-2.6');
+    expect(cfg.default_music_model).toBe('music-3.0');
   });
 
   it('rejects empty string default model', () => {
@@ -110,7 +110,7 @@ describe('parseConfigFile', () => {
       output: 'json',
       timeout: 120,
       proxy: 'http://proxy:3128',
-      default_text_model: 'MiniMax-M2.7',
+      default_text_model: 'MiniMax-M3',
     });
     expect(cfg.api_key).toBe('sk-cp-test');
     expect(cfg.region).toBe('cn');
@@ -118,7 +118,7 @@ describe('parseConfigFile', () => {
     expect(cfg.output).toBe('json');
     expect(cfg.timeout).toBe(120);
     expect(cfg.proxy).toBe('http://proxy:3128');
-    expect(cfg.default_text_model).toBe('MiniMax-M2.7');
+    expect(cfg.default_text_model).toBe('MiniMax-M3');
   });
 
   it('silently ignores unknown keys', () => {

--- a/test/fixtures/text-chat-response.json
+++ b/test/fixtures/text-chat-response.json
@@ -8,7 +8,7 @@
       "text": "Hello! How can I help you today?"
     }
   ],
-  "model": "MiniMax-M2.7",
+  "model": "MiniMax-M3",
   "stop_reason": "end_turn",
   "usage": {
     "input_tokens": 12,

--- a/test/sdk/quota.test.ts
+++ b/test/sdk/quota.test.ts
@@ -8,7 +8,7 @@ describe('MiniMaxSDK.quota', () => {
         return new Response(JSON.stringify({
           model_remains: [
             {
-              model_name: 'MiniMax-M2.7',
+              model_name: 'MiniMax-M3',
               start_time: 0,
               end_time: 9999999999,
               remains_time: 1000,
@@ -41,7 +41,7 @@ describe('MiniMaxSDK.quota', () => {
       const result = await sdk.quota.info();
 
       expect(result.model_remains).toHaveLength(1);
-      expect(result.model_remains[0].model_name).toBe('MiniMax-M2.7');
+      expect(result.model_remains[0].model_name).toBe('MiniMax-M3');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/test/sdk/text.test.ts
+++ b/test/sdk/text.test.ts
@@ -18,7 +18,7 @@ describe('MiniMaxSDK.text', () => {
           type: 'message',
           role: 'assistant',
           content: [{ type: 'text', text: 'Hello!' }],
-          model: 'MiniMax-M2.7',
+          model: 'MiniMax-M3',
           stop_reason: 'end_turn',
           usage: { input_tokens: 10, output_tokens: 5 },
         }),

--- a/test/utils/model-defaults.test.ts
+++ b/test/utils/model-defaults.test.ts
@@ -33,18 +33,18 @@ function resolveModel(
 
 describe('model resolution (flag > config default > fallback)', () => {
   it('uses flag when provided', () => {
-    const model = resolveModel('defaultTextModel', 'MiniMax-M2.7', baseConfig, { model: 'MiniMax-M2.7-highspeed' });
-    expect(model).toBe('MiniMax-M2.7-highspeed');
+    const model = resolveModel('defaultTextModel', 'MiniMax-M3', baseConfig, { model: 'MiniMax-M2.7' });
+    expect(model).toBe('MiniMax-M2.7');
   });
 
   it('falls back to config default when flag is absent', () => {
-    const model = resolveModel('defaultTextModel', 'MiniMax-M2.7', { ...baseConfig, defaultTextModel: 'MiniMax-M2.7-highspeed' }, {});
-    expect(model).toBe('MiniMax-M2.7-highspeed');
+    const model = resolveModel('defaultTextModel', 'MiniMax-M3', { ...baseConfig, defaultTextModel: 'MiniMax-M3' }, {});
+    expect(model).toBe('MiniMax-M3');
   });
 
   it('falls back to hardcoded when neither flag nor config', () => {
-    const model = resolveModel('defaultTextModel', 'MiniMax-M2.7', baseConfig, {});
-    expect(model).toBe('MiniMax-M2.7');
+    const model = resolveModel('defaultTextModel', 'MiniMax-M3', baseConfig, {});
+    expect(model).toBe('MiniMax-M3');
   });
 
   it('flag overrides config default', () => {
@@ -58,7 +58,7 @@ describe('model resolution (flag > config default > fallback)', () => {
   });
 
   it('handles music model default', () => {
-    const model = resolveModel('defaultMusicModel', 'music-2.6', { ...baseConfig, defaultMusicModel: 'music-2.6' }, {});
-    expect(model).toBe('music-2.6');
+    const model = resolveModel('defaultMusicModel', 'music-3.0', { ...baseConfig, defaultMusicModel: 'music-3.0' }, {});
+    expect(model).toBe('music-3.0');
   });
 });


### PR DESCRIPTION
Bump package version to 1.0.18 and align music/text defaults with music-3.0 and MiniMax-M3.

Includes the earlier music/text model updates, docs, tests, and build metadata.

Tagging will wait until after merge.