### PR TITLE
fix: report unavailable quota models

### DIFF
--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -30,10 +30,11 @@ interface Labels {
   resetsIn: string;
   noData: string;
   now: string;
+  notInPlan: string;
 }
 
-const LABELS_EN: Labels = { dashboard: 'TokenPlan Quota', week: 'Week', current: 'Left', weekly: 'Wk left', resetsIn: 'Reset', noData: 'No quota data available.', now: 'now' };
-const LABELS_CN: Labels = { dashboard: 'TokenPlan 配额面板', week: '周期', current: '剩余', weekly: '周剩余', resetsIn: '重置', noData: '暂无配额数据', now: '即将' };
+const LABELS_EN: Labels = { dashboard: 'TokenPlan Quota', week: 'Week', current: 'Left', weekly: 'Wk left', resetsIn: 'Reset', noData: 'No quota data available.', now: 'now', notInPlan: 'not in plan' };
+const LABELS_CN: Labels = { dashboard: 'TokenPlan 配额面板', week: '周期', current: '剩余', weekly: '周剩余', resetsIn: '重置', noData: '暂无配额数据', now: '即将', notInPlan: '不在当前套餐中' };
 
 const MODEL_NAME_CN: Record<string, string> = {
   'general': '通用',
@@ -82,6 +83,16 @@ const MAX_DISPLAY_PCT = 200;
 // (per the status enum: 1=normal, 2=exhausted, 3=unlimited).
 function isUnweekly(status: number | undefined | null): boolean {
   return status === 3;
+}
+
+function isUnavailablePlan(model: QuotaModelRemain): boolean {
+  // Weekly status 3 is normally unlimited. When both windows are status 3 and
+  // both totals are zero, however, the API uses the same status for a model
+  // that has no quota bucket in the current plan (see issue #173).
+  return model.current_interval_total_count === 0
+    && model.current_weekly_total_count === 0
+    && model.current_interval_status === 3
+    && model.current_weekly_status === 3;
 }
 
 function clampPct(value: number): number {
@@ -154,6 +165,14 @@ function renderMetric(
   return `${label} ${bar}`;
 }
 
+function renderUnavailableMetric(label: string, unavailableLabel: string, color: boolean): string {
+  if (color) {
+    const bar = `${BG_EMPTY}${' '.repeat(COMPACT_BAR_WIDTH)}${R}`;
+    return `${D}${label}${R} ${bar} ${FG_RED}${B}${unavailableLabel}${R}`;
+  }
+  return `${label} [${'.'.repeat(COMPACT_BAR_WIDTH)}] ${unavailableLabel}`;
+}
+
 function boxLine(w: number, l: string, f: string, r: string, c: boolean): string {
   return c ? `${D}${l}${f.repeat(w)}${r}${R}` : `+${'-'.repeat(w)}+`;
 }
@@ -169,24 +188,31 @@ export function renderQuotaTable(models: QuotaModelRemain[], config: Config): vo
 
   const rows = models.map((m) => {
     const displayName = displayModelName(m.model_name, config.region);
-    const current = renderMetric(
-      L.current,
-      m.current_interval_usage_count,
-      m.current_interval_total_count,
-      m.current_interval_remaining_percent,
-      useColor,
-    );
-    const weekly = renderMetric(
-      L.weekly,
-      m.current_weekly_usage_count,
-      m.current_weekly_total_count,
-      m.current_weekly_remaining_percent,
-      useColor,
-      m.weekly_boost_permille,
-      isUnweekly(m.current_weekly_status),
-      config.region === 'cn' ? UNLIMITED_LABEL_CN : UNLIMITED_LABEL_EN,
-    );
-    const reset = `${L.resetsIn} ${formatDuration(m.remains_time, L.now)}`;
+    const unavailable = isUnavailablePlan(m);
+    const current = unavailable
+      ? renderUnavailableMetric(L.current, L.notInPlan, useColor)
+      : renderMetric(
+        L.current,
+        m.current_interval_usage_count,
+        m.current_interval_total_count,
+        m.current_interval_remaining_percent,
+        useColor,
+      );
+    const weekly = unavailable
+      ? renderUnavailableMetric(L.weekly, L.notInPlan, useColor)
+      : renderMetric(
+        L.weekly,
+        m.current_weekly_usage_count,
+        m.current_weekly_total_count,
+        m.current_weekly_remaining_percent,
+        useColor,
+        m.weekly_boost_permille,
+        isUnweekly(m.current_weekly_status),
+        config.region === 'cn' ? UNLIMITED_LABEL_CN : UNLIMITED_LABEL_EN,
+      );
+    const reset = unavailable
+      ? `${L.resetsIn} —`
+      : `${L.resetsIn} ${formatDuration(m.remains_time, L.now)}`;
     return { displayName, current, weekly, reset };
   });
 

--- a/test/output/quota-table.test.ts
+++ b/test/output/quota-table.test.ts
@@ -253,4 +253,41 @@ describe('renderQuotaTable', () => {
     expect(output).toContain('unlimited');
     expect(output).not.toContain('100%');
   });
+
+  it('renders a zero-allocation model as unavailable instead of unlimited', () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(
+        [
+          {
+            ...createModel(),
+            model_name: 'video',
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 100,
+            current_interval_status: 3,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 100,
+            current_weekly_status: 3,
+          },
+        ],
+        { ...createConfig(), noColor: true },
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    expect(output).toContain('not in plan');
+    expect(output).toContain('Reset —');
+    expect(output).not.toContain('unlimited');
+    expect(output).not.toContain('100%');
+  });
 });


### PR DESCRIPTION
## Summary

- detect the zero-allocation sentinel returned for models that are not included in the current Token Plan
- render both quota windows as `not in plan` instead of `100%` / `unlimited`
- suppress the misleading reset countdown for unavailable models
- keep the existing weekly-unlimited behavior when only the weekly window has status 3

## Root cause

The quota API reuses status 3 for two different states. A normal model can have an unlimited weekly window, while an unavailable model is returned with both totals set to zero and both current and weekly statuses set to 3. The renderer treated every weekly status 3 as unlimited, so the video row described in the issue looked usable even though generation was rejected as 0/0.

## Impact

Users now see that a model is not part of their plan before attempting a generation request, instead of being told that it has full or unlimited quota.

## Validation

- `bun test test/output/quota-table.test.ts`
- `bun run typecheck`
- `bun run lint` (no errors; two pre-existing warnings)
- `bun test`
- `bun run build:dev`

Fixes #173

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786989067&installation_id=146985763&pr_number=205&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F205&signature=d3b1069abcf16ba5d65a2a7d589056d78cfad330059aee898edfcb0ce4605cbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->