### PR TITLE
fix: reject truncated downloads

### DIFF
--- a/src/files/download.ts
+++ b/src/files/download.ts
@@ -37,7 +37,11 @@ export async function downloadFile(
         throw new CLIError(`Download failed: HTTP ${res.status}`, ExitCode.GENERAL);
       }
 
-      const contentLength = Number(res.headers.get('content-length') || 0);
+      // fetch transparently decodes compressed responses, so Content-Length
+      // only describes the readable body when no Content-Encoding is present.
+      const contentLength = res.headers.get('content-encoding')
+        ? 0
+        : Number(res.headers.get('content-length') || 0);
       const reader = res.body?.getReader();
       if (!reader) throw new CLIError('No response body', ExitCode.GENERAL);
 
@@ -68,6 +72,13 @@ export async function downloadFile(
 
           received += value.byteLength;
           progress?.update(received);
+        }
+
+        if (contentLength > 0 && received !== contentLength) {
+          throw new CLIError(
+            `Download truncated: expected ${contentLength} bytes, received ${received}.`,
+            ExitCode.NETWORK,
+          );
         }
         readComplete = true;
       } finally {

--- a/test/files/download.test.ts
+++ b/test/files/download.test.ts
@@ -71,4 +71,41 @@ describe('downloadFile', () => {
     expect(existsSync(destPath)).toBe(true);
     expect(readdirSync(dir)).toEqual(['video.mp4']);
   });
+
+  it('rejects a cleanly ended response whose body is shorter than Content-Length', async () => {
+    const dir = makeTempDir();
+    const destPath = join(dir, 'video.mp4');
+    writeFileSync(destPath, 'original');
+
+    globalThis.fetch = (async () => new Response(new TextEncoder().encode('new'), {
+      status: 200,
+      headers: { 'content-length': '10' },
+    })) as unknown as typeof fetch;
+
+    await expect(
+      downloadFile('https://example.com/video.mp4', destPath, { quiet: true, retries: 0 }),
+    ).rejects.toThrow('Download truncated: expected 10 bytes, received 3');
+
+    expect(readFileSync(destPath, 'utf-8')).toBe('original');
+    expect(readdirSync(dir)).toEqual(['video.mp4']);
+  });
+
+  it('does not compare decoded response bytes with compressed Content-Length', async () => {
+    const dir = makeTempDir();
+    const destPath = join(dir, 'video.mp4');
+
+    globalThis.fetch = (async () => new Response(new TextEncoder().encode('new'), {
+      status: 200,
+      headers: {
+        'content-encoding': 'gzip',
+        'content-length': '10',
+      },
+    })) as unknown as typeof fetch;
+
+    await expect(
+      downloadFile('https://example.com/video.mp4', destPath, { quiet: true, retries: 0 }),
+    ).resolves.toEqual({ size: 3 });
+
+    expect(readFileSync(destPath, 'utf-8')).toBe('new');
+  });
 });


### PR DESCRIPTION
## Summary

- compare received bytes with `Content-Length` before atomically replacing the destination
- reject cleanly ended but incomplete responses as truncated downloads
- preserve an existing destination and remove the partial temporary file on mismatch
- skip the byte comparison for transparently decoded `Content-Encoding` responses

## Root cause

The downloader handled explicit stream errors, but a response that ended cleanly before delivering its declared byte count was accepted. The partial temporary file was then renamed to the final destination, silently producing a corrupt artifact.

## Impact

Image, video, and other shared downloader users no longer receive silently truncated files when a server or intermediary closes a response early.

## Validation

- `bun test test/files/download.test.ts`
- `bun run typecheck`
- `bun run lint` (no errors; two pre-existing warnings)
- `bun test`
- `bun run build:dev`

Refs #79 (item 6: network truncation goes undetected)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786989071&installation_id=146985763&pr_number=206&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F206&signature=a869a21f58f274c4ab9702ed2a069cdbee188c63978e3d2d3234f580f3a7c963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->