### PR TITLE
fix: support stdin-backed file options on Windows

### DIFF
--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../types/api';
 import { readFileSync } from 'fs';
 import { isInteractive } from '../../utils/env';
+import { readTextFromPathOrStdin } from '../../utils/fs';
 import { promptText, failIfMissing } from '../../utils/prompt';
 
 // ---------------------------------------------------------------------------
@@ -104,9 +105,7 @@ function parseMessages(flags: GlobalFlags): ParsedMessages {
 
   if (flags.messagesFile) {
     const filePath = flags.messagesFile as string;
-    const raw = filePath === '-'
-      ? readFileSync('/dev/stdin', 'utf-8')
-      : readFileSync(filePath, 'utf-8');
+    const raw = readTextFromPathOrStdin(filePath);
     const parsed = JSON.parse(raw) as Array<{ role: string; content: string | ContentBlock[] }>;
     for (const m of parsed) {
       if (m.role === 'system') {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,11 @@
 import { readFileSync } from 'fs';
 
+export function resolveTextInput(path: string): string | number {
+  // File descriptor 0 is stdin on every platform supported by Node. `/dev/stdin`
+  // only exists on POSIX systems, so using it breaks `--*-file -` on Windows.
+  return path === '-' ? 0 : path;
+}
+
 export function readTextFromPathOrStdin(path: string): string {
-  return readFileSync(path === '-' ? '/dev/stdin' : path, 'utf-8');
+  return readFileSync(resolveTextInput(path), 'utf-8');
 }

--- a/test/utils/fs.test.ts
+++ b/test/utils/fs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readTextFromPathOrStdin, resolveTextInput } from '../../src/utils/fs';
+
+describe('readTextFromPathOrStdin', () => {
+  it('uses file descriptor zero for the stdin marker on every platform', () => {
+    expect(resolveTextInput('-')).toBe(0);
+  });
+
+  it('keeps ordinary file paths unchanged and reads their text', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mmx-fs-test-'));
+    const path = join(dir, 'input.txt');
+    writeFileSync(path, 'hello from a file', 'utf-8');
+
+    try {
+      expect(resolveTextInput(path)).toBe(path);
+      expect(readTextFromPathOrStdin(path)).toBe('hello from a file');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fix cross-platform support for documented `-` stdin inputs:

- replace the POSIX-only `/dev/stdin` path with file descriptor `0`
- route `mmx text chat --messages-file -` through the shared helper
- keep `--text-file -` and `--lyrics-file -` working through the same helper on Windows, macOS, and Linux

## Root cause

The shared reader and text-chat command hard-coded `/dev/stdin`, which does not exist on Windows.

## Tests

- Adds regression coverage that the stdin marker resolves to file descriptor `0`.
- Isolated TypeScript check passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787125478&installation_id=146985763&pr_number=208&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F208&signature=a7bc6c6a22e7e58f6e628be97ec11b3386901d503bb90bbdd89dbe74c13e9874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->