### PR TITLE
fix: honor configured output format in quota show

### DIFF
--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -28,7 +28,9 @@ export default defineCommand({
     const url = quotaEndpoint(config.baseUrl);
     const response = await requestJson<QuotaApiResponse>(config, { url });
     const models = response.model_remains || [];
-    const format = detectOutputFormat(flags.output as string | undefined);
+    // `loadConfig()` has already resolved --output, MINIMAX_OUTPUT, and the
+    // saved config value. Reading flags again drops the latter two sources.
+    const format = detectOutputFormat(config.output);
 
     if (format !== 'text') {
       console.log(formatOutput(response, format));

--- a/test/commands/quota/show.test.ts
+++ b/test/commands/quota/show.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, it, expect } from 'bun:test';
 import { default as showCommand } from '../../../src/commands/quota/show';
+import { createMockServer, jsonResponse, type MockServer } from '../../helpers/mock-server';
 
 const baseConfig = {
   apiKey: 'test-key',
@@ -28,6 +29,12 @@ const baseFlags = {
 };
 
 describe('quota show command', () => {
+  let server: MockServer;
+
+  afterEach(() => {
+    server?.close();
+  });
+
   it('has correct name', () => {
     expect(showCommand.name).toBe('quota show');
   });
@@ -44,6 +51,35 @@ describe('quota show command', () => {
       expect(captured).toContain('Would fetch quota');
     } finally {
       console.log = origLog;
+    }
+  });
+
+  it('honors JSON output resolved from config when no output flag is present', async () => {
+    server = createMockServer({
+      routes: {
+        '/v1/token_plan/remains': () => jsonResponse({
+          model_remains: [],
+          base_resp: { status_code: 0, status_msg: 'ok' },
+        }),
+      },
+    });
+
+    const originalIsTTY = process.stdout.isTTY;
+    const originalLog = console.log;
+    let captured = '';
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    console.log = (message: string) => { captured += message; };
+
+    try {
+      await showCommand.execute(
+        { ...baseConfig, baseUrl: server.url, output: 'json' },
+        baseFlags,
+      );
+
+      expect(JSON.parse(captured)).toMatchObject({ model_remains: [] });
+    } finally {
+      console.log = originalLog;
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
     }
   });
 


### PR DESCRIPTION
## Summary

Make `mmx quota show` use the output format already resolved by configuration.

## Root cause

`loadConfig()` resolves `--output`, `MINIMAX_OUTPUT`, and the saved config value into `config.output`, but `quota show` re-read only `flags.output`. In a TTY, this caused `MINIMAX_OUTPUT=json` and `mmx config set --key output --value json` to be ignored.

## Tests

- Adds a TTY regression test proving configured JSON output is emitted without an explicit `--output` flag.
- Isolated TypeScript check passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787125502&installation_id=146985763&pr_number=209&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F209&signature=969234031367d6727a01be837ba5067d646e7d14865ee1bceb70b7fae74d1eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->