### PR TITLE
feat(text): register MiniMax-M2.7 as a text model option

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -44,6 +44,9 @@ for await (const event of stream) {
 }
 ```
 
+Supported text models: `MiniMax-M3` (default) and `MiniMax-M2.7`. Pass either
+as the `model` field; omit it to use the default.
+
 ### Image
 
 ```typescript

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -46,7 +46,7 @@ Always use these flags in non-interactive (agent/CI) contexts:
 
 ### text chat
 
-Chat completion. Default model: `MiniMax-M3`.
+Chat completion. Default model: `MiniMax-M3`. Supported models: `MiniMax-M3` (default), `MiniMax-M2.7`.
 
 ```bash
 mmx text chat --message <text> [flags]
@@ -57,7 +57,7 @@ mmx text chat --message <text> [flags]
 | `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
 | `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
 | `--system <text>` | string | System prompt |
-| `--model <model>` | string | Model ID (default: `MiniMax-M3`) |
+| `--model <model>` | string | Model ID: `MiniMax-M3` (default) or `MiniMax-M2.7` |
 | `--max-tokens <n>` | number | Max tokens (default: 4096) |
 | `--temperature <n>` | number | Sampling temperature (0.0, 1.0] |
 | `--top-p <n>` | number | Nucleus sampling threshold |

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -17,6 +17,7 @@ import type {
 import { readFileSync } from 'fs';
 import { isInteractive } from '../../utils/env';
 import { promptText, failIfMissing } from '../../utils/prompt';
+import { TEXT_MODELS, textModel } from './models';
 
 // ---------------------------------------------------------------------------
 // Thinking indicator — dynamic spinner + color-cycling label
@@ -159,7 +160,7 @@ export default defineCommand({
   apiDocs: '/docs/api-reference/text-post',
   usage: 'mmx text chat --message <text> [flags]',
   options: [
-    { flag: '--model <model>', description: 'Model ID (default: MiniMax-M3)' },
+    { flag: '--model <model>', description: `Model ID (default: ${TEXT_MODELS[0]}; supported: ${TEXT_MODELS.join(', ')})` },
     { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role)', required: true, type: 'array' },
     { flag: '--messages-file <path>',  description: 'JSON file with messages array (use - for stdin)' },
     { flag: '--system <text>',         description: 'System prompt' },
@@ -195,9 +196,14 @@ export default defineCommand({
       }
     }
 
-    const model = (flags.model as string)
-      || config.defaultTextModel
-      || 'MiniMax-M3';
+    const model = textModel(config, flags.model as string | undefined);
+    if (flags.model && !TEXT_MODELS.includes(model as typeof TEXT_MODELS[number])) {
+      throw new CLIError(
+        `Invalid model "${model}". Valid models: ${TEXT_MODELS.join(', ')}`,
+        ExitCode.USAGE,
+        `mmx text chat --model ${TEXT_MODELS[0]}`,
+      );
+    }
     const format = detectOutputFormat(config.output);
     const shouldStream = flags.stream === true || (
       flags.stream === undefined

--- a/src/commands/text/models.ts
+++ b/src/commands/text/models.ts
@@ -1,0 +1,44 @@
+import type { Config } from '../../config/schema';
+
+/**
+ * Text chat models supported by the MiniMax Messages API.
+ *
+ * This registry is the single source of truth for valid `--model` values in
+ * the `text chat` / `text repl` commands and the `sdk.text` module. Add new
+ * model IDs here when the Messages API ships them so the CLI, SDK, help text,
+ * and validation stay in lockstep.
+ */
+export const TEXT_MODELS = [
+  'MiniMax-M3',
+  'MiniMax-M2.7',
+] as const;
+
+export const DEFAULT_TEXT_MODEL = 'MiniMax-M3';
+
+function includesModel(models: readonly string[], model: string): boolean {
+  return models.includes(model);
+}
+
+/**
+ * Resolve the effective text model using the same precedence as the other
+ * modalities: explicit flag > configured default (when it is a registered
+ * model) > built-in default. A configured default that is not in
+ * {@link TEXT_MODELS} is ignored so users can still override with `--model`.
+ */
+export function textModel(config: Config, model?: string): string {
+  if (typeof model === 'string' && model.length > 0) return model;
+  if (
+    config.defaultTextModel
+    && includesModel(TEXT_MODELS, config.defaultTextModel)
+  ) {
+    return config.defaultTextModel;
+  }
+  return DEFAULT_TEXT_MODEL;
+}
+
+/**
+ * Returns true when `model` is a registered text model ID.
+ */
+export function isTextModel(model: string): boolean {
+  return includesModel(TEXT_MODELS, model);
+}

--- a/src/commands/text/repl.ts
+++ b/src/commands/text/repl.ts
@@ -9,6 +9,7 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { ChatMessage, ChatRequest, StreamEvent } from '../../types/api';
 import { writeFileSync } from 'node:fs';
+import { TEXT_MODELS, textModel } from './models';
 
 // ---------------------------------------------------------------------------
 // ANSI helpers
@@ -294,7 +295,7 @@ export default defineCommand({
   description: 'Start an interactive multi-turn chat session',
   usage: 'mmx text repl [flags]',
   options: [
-    { flag: '--model <model>',     description: 'Model ID (default: MiniMax-M3)' },
+    { flag: '--model <model>',     description: `Model ID (default: ${TEXT_MODELS[0]}; supported: ${TEXT_MODELS.join(', ')})` },
     { flag: '--system <text>',     description: 'System prompt' },
     { flag: '--max-tokens <n>',    description: 'Maximum tokens per response (default: 4096)', type: 'number' },
     { flag: '--temperature <n>',   description: 'Sampling temperature (0.0, 1.0]', type: 'number' },
@@ -321,11 +322,21 @@ export default defineCommand({
     const dim  = config.noColor ? '' : '\x1b[2m';
     const reset = config.noColor ? '' : '\x1b[0m';
 
+    // ---- Validate --model up-front (same surface as chat) ----
+    const model = textModel(config, flags.model as string | undefined);
+    if (flags.model && !TEXT_MODELS.includes(model as typeof TEXT_MODELS[number])) {
+      throw new CLIError(
+        `Invalid model "${model}". Valid models: ${TEXT_MODELS.join(', ')}`,
+        ExitCode.USAGE,
+        `mmx text repl --model ${TEXT_MODELS[0]}`,
+      );
+    }
+
     // ---- Initialize state ----
     const state: ReplState = {
       messages: [],
       system: flags.system as string | undefined,
-      model: (flags.model as string) || config.defaultTextModel || 'MiniMax-M3',
+      model,
       maxTokens: (flags.maxTokens as number) ?? 4096,
       temperature: flags.temperature !== undefined ? flags.temperature as number : undefined,
       topP: flags.topP !== undefined ? flags.topP as number : undefined,

--- a/src/sdk/text/index.ts
+++ b/src/sdk/text/index.ts
@@ -3,6 +3,7 @@ import { chatEndpoint } from "../../client/endpoints";
 import { ChatRequest, ChatResponse, StreamEvent } from "../../types/api";
 import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
+import { TEXT_MODELS, textModel } from "../../commands/text/models";
 
 export class TextSDK extends Client {
   private async *chatStream(body: Partial<ChatRequest>): AsyncGenerator<StreamEvent> {
@@ -54,9 +55,17 @@ export class TextSDK extends Client {
       );
     }
 
+    const model = textModel(this.config, params.model);
+    if (params.model && !TEXT_MODELS.includes(model as typeof TEXT_MODELS[number])) {
+      throw new SDKError(
+        `Invalid model "${model}". Valid models: ${TEXT_MODELS.join(', ')}`,
+        ExitCode.USAGE,
+      );
+    }
+
     return {
       ...params,
-      model: params.model ?? 'MiniMax-M3',
+      model,
       max_tokens: params.max_tokens ?? 4096,
     } as ChatRequest;
   }

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -302,4 +302,38 @@ describe('text chat command', () => {
       console.log = originalLog;
     }
   });
+
+  it('rejects an unregistered --model with a usage error', async () => {
+    const { default: chatCommand } = await import('../../../src/commands/text/chat');
+
+    const config: Config = {
+      apiKey: 'test-key',
+      region: 'global' as const,
+      baseUrl: 'https://api.mmx.io',
+      output: 'json',
+      timeout: 10,
+      verbose: false,
+      quiet: false,
+      noColor: true,
+      yes: false,
+      dryRun: true,
+      nonInteractive: true,
+      async: false,
+    };
+
+    await expect(
+      chatCommand.execute(config, {
+        message: ['Hello'],
+        model: 'not-a-real-model',
+        quiet: false,
+        verbose: false,
+        noColor: true,
+        yes: false,
+        dryRun: true,
+        help: false,
+        nonInteractive: true,
+        async: false,
+      }),
+    ).rejects.toThrow('Invalid model "not-a-real-model"');
+  });
 });

--- a/test/commands/text/models.test.ts
+++ b/test/commands/text/models.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  TEXT_MODELS,
+  DEFAULT_TEXT_MODEL,
+  textModel,
+  isTextModel,
+} from '../../../src/commands/text/models';
+import type { Config } from '../../../src/config/schema';
+
+const baseConfig: Config = {
+  region: 'global',
+  baseUrl: 'https://api.minimax.io',
+  output: 'text',
+  timeout: 300,
+  verbose: false,
+  quiet: false,
+  noColor: true,
+  yes: false,
+  dryRun: false,
+  nonInteractive: true,
+  async: false,
+};
+
+describe('text model registry', () => {
+  it('registers the current MiniMax text models', () => {
+    expect(TEXT_MODELS).toContain('MiniMax-M3');
+    expect(TEXT_MODELS).toContain('MiniMax-M2.7');
+    expect(DEFAULT_TEXT_MODEL).toBe('MiniMax-M3');
+  });
+
+  it('uses the explicit flag when provided', () => {
+    expect(textModel(baseConfig, 'MiniMax-M2.7')).toBe('MiniMax-M2.7');
+  });
+
+  it('falls back to a registered config default', () => {
+    const cfg: Config = { ...baseConfig, defaultTextModel: 'MiniMax-M2.7' };
+    expect(textModel(cfg, undefined)).toBe('MiniMax-M2.7');
+  });
+
+  it('ignores an unregistered config default', () => {
+    const cfg: Config = { ...baseConfig, defaultTextModel: 'some-other-model' };
+    expect(textModel(cfg, undefined)).toBe(DEFAULT_TEXT_MODEL);
+  });
+
+  it('falls back to the built-in default when nothing is set', () => {
+    expect(textModel(baseConfig, undefined)).toBe(DEFAULT_TEXT_MODEL);
+  });
+
+  it('isTextModel recognizes registered ids only', () => {
+    expect(isTextModel('MiniMax-M3')).toBe(true);
+    expect(isTextModel('MiniMax-M2.7')).toBe(true);
+    expect(isTextModel('not-a-model')).toBe(false);
+  });
+});

--- a/test/sdk/text.test.ts
+++ b/test/sdk/text.test.ts
@@ -87,4 +87,10 @@ describe('TextSDK.validateParams', () => {
       sdk.chat({ messages: [{ role: 'user', content: 'Hi' }] }),
     ).rejects.not.toThrow('At least one message');
   });
+
+  it('rejects an unregistered model', async () => {
+    await expect(
+      sdk.chat({ messages: [{ role: 'user', content: 'Hi' }], model: 'not-a-real-model' }),
+    ).rejects.toThrow('Invalid model "not-a-real-model"');
+  });
 });


### PR DESCRIPTION
Reason: text SDK defaults to MiniMax-M3 but had no MiniMax-M2.7 model option or model registry entry.

## Changes

- Add a text model registry (`src/commands/text/models.ts`) listing the supported MiniMax text model IDs (`MiniMax-M3` default, `MiniMax-M2.7`), mirroring the existing music model registry pattern (`src/commands/music/models.ts`).
- `text chat` and `text repl` now resolve the effective model through the registry and validate an explicit `--model` value against it, surfacing `MiniMax-M2.7` as a first-class option in `--help` and rejecting unknown model IDs with a clear usage error.
- `sdk.text` resolves its default model from the same registry and validates an explicit `model` field the same way, keeping the CLI and SDK in lockstep.
- Help text, `SDK.md`, and `skill/SKILL.md` list the supported text models.

## Checks

- typecheck: `bun run typecheck` (tsc --noEmit) — clean
- lint: `bun run lint` — 0 errors
- tests: `bun test` — 414 pass / 0 fail (added coverage for the registry, the chat invalid-model path, and the SDK invalid-model path)
- build: `bun run build` — `dist/mmx.mjs` + `dist/sdk.mjs` produced

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787833224&installation_model_id=427615&pr_number=210&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F210&signature=78aaea29697a73d20158570fe98e0096a0ea14b4ee2152940b5235bb9d083e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->