### PR TITLE
fix(config): drop --base-url flag and MINIMAX_BASE_URL env

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -1,5 +1,7 @@
 import type { GlobalFlags } from './types/flags';
 import type { OptionDef } from './command';
+import { CLIError } from './errors/base';
+import { ExitCode } from './errors/codes';
 
 /** Recognised spellings for an explicit boolean flag value, e.g. `--flag=false`. */
 const BOOLEAN_TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
@@ -116,6 +118,17 @@ export function parseFlags(argv: string[], options: OptionDef[]): GlobalFlags {
       }
 
       const camelKey = kebabToCamel(key);
+
+      // Flags removed in newer versions — give users a clear pointer to the
+      // current way of doing the same thing instead of silently dropping
+      // their input.
+      if (key === 'base-url') {
+        throw new CLIError(
+          'Flag --base-url was removed.',
+          ExitCode.USAGE,
+          'Set base_url via `mmx config set --key base_url --value <url>`.',
+        );
+      }
 
       if (schema.booleans.has(camelKey)) {
         // A bare boolean flag (`--flag`) is true. Honour an explicit value

--- a/src/command.ts
+++ b/src/command.ts
@@ -44,7 +44,6 @@ export function defineCommand(spec: CommandSpec): Command {
 export const GLOBAL_OPTIONS: OptionDef[] = [
   { flag: '--api-key <key>',     description: 'API key' },
   { flag: '--region <region>',   description: 'API region: global, cn' },
-  { flag: '--base-url <url>',    description: 'API base URL' },
   { flag: '--output <format>',   description: 'Output format: text, json' },
   { flag: '--timeout <seconds>', description: 'Request timeout', type: 'number' },
   { flag: '--quiet',             description: 'Suppress non-essential output' },

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -82,9 +82,8 @@ export function loadConfig(flags: GlobalFlags): Config {
   const needsRegionDetection = !explicitRegion
     && (!cachedRegion || (activeKey !== undefined && activeKey !== file.api_key));
 
-  const baseUrl = flags.baseUrl
-    || process.env.MINIMAX_BASE_URL
-    || file.base_url
+  // env/flag removed intentionally — see PR for context.
+  const baseUrl = file.base_url
     || file.oauth?.resource_url
     || REGIONS[region]
     || REGIONS.global;

--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -35,7 +35,7 @@ export function handleError(err: unknown): never {
       return handleError(timeout);
     }
 
-    // Detect TypeError from fetch with invalid URL (e.g., malformed MINIMAX_BASE_URL)
+    // Detect TypeError from fetch with invalid URL (e.g., malformed base_url in config.json)
     if (err instanceof TypeError && err.message === "fetch failed") {
       const networkErr = new CLIError(
         "Network request failed.",

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -218,8 +218,7 @@ ${b('Resources:')}
 
 ${b('Global Flags:')}
   ${a('--api-key <key>')}        ${d('API key (overrides all other auth)')}
-  ${a('--region <region>')}      ${d('API region: global (default), cn')}
-  ${a('--base-url <url>')}       ${d('API base URL (overrides region)')}
+  ${a('--region <region>')}      ${d('API region: global (default), cn)')}
   ${a('--output <format>')}      ${d('Output format: text, json')}
   ${a('--quiet')}                ${d('Suppress non-essential output')}
   ${a('--verbose')}              ${d('Print HTTP request/response details')}

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,6 +1,5 @@
 export interface GlobalFlags {
   apiKey?: string;
-  baseUrl?: string;
   output?: string;
   quiet: boolean;
   verbose: boolean;

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'bun:test';
 import { parseFlags } from '../src/args';
 import type { OptionDef } from '../src/command';
+import { GLOBAL_OPTIONS } from '../src/command';
+import { CLIError } from '../src/errors/base';
 
 const OPTIONS: OptionDef[] = [
   { flag: '--timeout <seconds>', description: 'Request timeout', type: 'number' },
@@ -51,5 +53,31 @@ describe('parseFlags', () => {
     expect(() => parseFlags(['--verbose='], OPTIONS)).toThrow(
       'Flag --verbose requires a boolean value',
     );
+  });
+});
+
+describe('parseFlags — removed flags', () => {
+  it('rejects --base-url (space form) as a CLIError with a migration hint', () => {
+    let caught: unknown;
+    try {
+      parseFlags(['--base-url', 'https://api.example', 'search', 'query'], GLOBAL_OPTIONS);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CLIError);
+    expect((caught as CLIError).message).toBe('Flag --base-url was removed.');
+    expect((caught as CLIError).hint).toMatch(/mmx config set.*base_url/);
+  });
+
+  it('rejects --base-url=... (= form) as a CLIError', () => {
+    expect(() =>
+      parseFlags(['--base-url=https://api.example', 'search', 'query'], GLOBAL_OPTIONS),
+    ).toThrow(/--base-url was removed/);
+  });
+
+  it('still parses unrelated flags normally', () => {
+    const flags = parseFlags(['--region', 'cn', '--quiet'], GLOBAL_OPTIONS);
+    expect(flags.region).toBe('cn');
+    expect(flags.quiet).toBe(true);
   });
 });

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { copyFileSync, mkdirSync, readFileSync, rmSync, unlinkSync } from 'fs';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadConfig, renameWithCrossDeviceFallback, writeConfigFile } from '../../src/config/loader';
@@ -154,5 +154,73 @@ describe('writeConfigFile', () => {
 
     const configPath = join(testDir, 'config.json');
     expect(JSON.parse(readFileSync(configPath, 'utf-8')).output).toBe('json');
+  });
+});
+
+describe('loadConfig — baseUrl source chain', () => {
+  const testDir = join(tmpdir(), `mmx-baseurl-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const configPath = join(testDir, 'config.json');
+  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+
+  beforeEach(() => {
+    process.env.MMX_CONFIG_DIR = testDir;
+    delete process.env.MINIMAX_BASE_URL;
+    delete process.env.MINIMAX_REGION;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.MMX_CONFIG_DIR;
+    else process.env.MMX_CONFIG_DIR = originalConfigDir;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(body: object): void {
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify(body));
+  }
+
+  it('uses file.base_url when set, with no flag or env', () => {
+    writeConfig({ base_url: 'https://api.from-file.example' });
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.from-file.example');
+  });
+
+  it('falls back to REGIONS.global when nothing is set', () => {
+    writeConfig({});
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.minimax.io');
+  });
+
+  it('falls back to REGIONS[region] when region is set in config file', () => {
+    writeConfig({ region: 'cn' });
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.minimaxi.com');
+  });
+
+  it('ignores MINIMAX_BASE_URL env even when file.base_url is missing', () => {
+    writeConfig({});
+    process.env.MINIMAX_BASE_URL = 'https://api.from-env.example';
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.minimax.io');
+  });
+
+  it('file.base_url wins over MINIMAX_BASE_URL env', () => {
+    writeConfig({ base_url: 'https://api.from-file.example' });
+    process.env.MINIMAX_BASE_URL = 'https://api.from-env.example';
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.from-file.example');
+  });
+
+  it('falls back to REGIONS[region] when region is set via env', () => {
+    writeConfig({});
+    process.env.MINIMAX_REGION = 'cn';
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.minimaxi.com');
+  });
+
+  it('ignores malformed file.base_url (not starting with http) and falls back to regions', () => {
+    writeConfig({ base_url: 'not-a-url' });
+    const cfg = loadConfig(baseFlags);
+    expect(cfg.baseUrl).toBe('https://api.minimax.io');
   });
 });


### PR DESCRIPTION
## What

Drop the `--base-url` global flag and the `MINIMAX_BASE_URL` env var. `baseUrl` is now sourced only from `config.json`'s `base_url` field (or, after OAuth login, the `oauth.resource_url` field stored alongside it).

## Why

An external tool was setting `MINIMAX_BASE_URL` in the user's shell, expecting mmx to leave it alone. mmx was intercepting it and breaking that tool's own routing. base_url is also fully redundant with `mmx config set --key base_url --value <url>`, so the explicit overrides are removed.

## Changes

- `src/command.ts` — drop `--base-url` from `GLOBAL_OPTIONS`
- `src/registry.ts` — drop `--base-url` line from help text
- `src/types/flags.ts` — drop `baseUrl?` field from `GlobalFlags`
- `src/config/loader.ts` — shorten baseUrl chain to `file.base_url || file.oauth?.resource_url || REGIONS[region] || REGIONS.global`
- `src/args.ts` — explicitly reject `--base-url` with a `CLIError(USAGE)` pointing at `mmx config set --key base_url`, so users no longer see their input silently dropped
- `src/errors/handler.ts` — refresh stale `MINIMAX_BASE_URL` example in the `fetch failed` branch comment

## Tests

- `test/config/loader.test.ts` — 7 new cases for the baseUrl source chain (file wins, region fallback, env ignored, malformed URL fallback). Uses `MMX_CONFIG_DIR` for cross-platform isolation.
- `test/args.test.ts` — 3 new cases for the `--base-url` rejection (space form, `=` form, and a happy-path smoke test).

`bun test`: 358/358 non-SDK tests pass. The 14 SDK failures are pre-existing and unrelated (live API integration tests that need network + a valid key).
`bun run lint`: clean.
`bun run typecheck`: clean.

## Side effects

- `mmx search query --base-url https://...` now errors with `Flag --base-url was removed.` and a migration hint.
- `export MINIMAX_BASE_URL=...` is silently ignored — the user's `~/.mmx/config.json` (or region default) wins. No warning by design.
- To set a custom base URL: `mmx config set --key base_url --value <url>`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788151881&installation_model_id=427615&pr_number=211&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F211&signature=79bda1f1eeee713e900806516757318c2c2688f30a64ec4f0c323ceaee644c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->