### PR TITLE
fix: support secret key balance usage

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -54,6 +54,20 @@ export function quotaEndpoint(baseUrl: string): string {
   return `${baseUrl}/v1/token_plan/remains`;
 }
 
+export function accountBalanceEndpoint(baseUrl: string): string {
+  return `${baseUrl}/account/query_balance`;
+}
+
+export function isSecretApiKey(apiKey: string): boolean {
+  return apiKey.startsWith('sk-api-');
+}
+
+export function usageEndpoint(baseUrl: string, apiKey: string): string {
+  return isSecretApiKey(apiKey)
+    ? accountBalanceEndpoint(baseUrl)
+    : quotaEndpoint(baseUrl);
+}
+
 export function fileUploadEndpoint(baseUrl: string): string {
   return `${baseUrl}/v1/files/upload`;
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -3,8 +3,8 @@ import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
 import { pickAuthMethod, pickOAuthRegion, runOAuthLogin } from '../../auth/setup';
 import { requestJson } from '../../client/http';
-import { quotaEndpoint } from '../../client/endpoints';
-import { renderQuotaTable } from '../../output/quota-table';
+import { quotaEndpoint, usageEndpoint } from '../../client/endpoints';
+import { renderUsage } from '../../output/usage';
 import { detectRegion } from '../../config/detect-region';
 
 import { getConfigPath } from '../../config/paths';
@@ -14,7 +14,7 @@ import { maskToken } from '../../utils/token';
 import type { Config, Region } from '../../config/schema';
 import { REGIONS } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { QuotaModelRemain } from '../../types/api';
+import type { AccountBalanceResponse, QuotaModelRemain } from '../../types/api';
 
 interface QuotaApiResponse {
   model_remains: QuotaModelRemain[];
@@ -53,9 +53,17 @@ function isNetworkUnavailable(error: unknown): boolean {
 
 async function showQuotaAfterLogin(config: Config): Promise<void> {
   try {
+    const apiKey = config.apiKey || config.fileApiKey;
+    if (apiKey && apiKey.startsWith('sk-api-')) {
+      const url = usageEndpoint(config.baseUrl, apiKey);
+      const response = await requestJson<AccountBalanceResponse>(config, { url });
+      renderUsage(response, config, apiKey);
+      return;
+    }
+
     const url = quotaEndpoint(config.baseUrl);
     const response = await requestJson<QuotaApiResponse>(config, { url });
-    renderQuotaTable(response.model_remains || [], config);
+    renderUsage(response, config);
   } catch {
     // Non-fatal — login succeeded, quota display is best-effort
   }
@@ -176,16 +184,20 @@ async function loginWithApiKey(
   // closed if neither can be confirmed; never persist a guessed fallback.
   const detected = explicitRegion ?? await detectRegion(key);
   const cfg: Config = { ...config, region: detected, baseUrl: REGIONS[detected], apiKey: key };
+  const url = usageEndpoint(cfg.baseUrl, key);
 
-  // Verify the selected region actually authorizes the quota endpoint.
+  // Verify the selected region actually authorizes the appropriate usage endpoint.
   try {
-    await requestJson<QuotaApiResponse>(cfg, { url: quotaEndpoint(cfg.baseUrl) });
+    await requestJson<QuotaApiResponse | AccountBalanceResponse>(cfg, { url });
   } catch (error) {
     if (error instanceof CLIError && error.exitCode === ExitCode.AUTH) {
+      const validationHint = key.startsWith('sk-api-')
+        ? 'Check that your key is valid and belongs to an API secret key.'
+        : 'Check that your key is valid and belongs to a Token Plan.';
       throw new CLIError(
         'API key validation failed.',
         ExitCode.AUTH,
-        'Check that your key is valid and belongs to a Token Plan.',
+        validationHint,
       );
     }
 

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -3,12 +3,12 @@ import { resolveCredential } from '../../auth/resolver';
 import { loadCredentials } from '../../auth/credentials';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { requestJson } from '../../client/http';
-import { quotaEndpoint } from '../../client/endpoints';
-import { renderQuotaTable } from '../../output/quota-table';
+import { quotaEndpoint, usageEndpoint } from '../../client/endpoints';
+import { renderUsage } from '../../output/usage';
 import { maskToken } from '../../utils/token';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { QuotaResponse } from '../../types/api';
+import type { AccountBalanceResponse, QuotaResponse } from '../../types/api';
 
 export default defineCommand({
   name: 'auth status',
@@ -36,6 +36,9 @@ export default defineCommand({
           }
         } else {
           result.key = maskToken(credential.token);
+          const url = usageEndpoint(config.baseUrl, credential.token);
+          const usage = await requestJson<AccountBalanceResponse | QuotaResponse>(config, { url });
+          result.usage = usage;
         }
         console.log(formatOutput(result, format));
         return;
@@ -57,6 +60,15 @@ export default defineCommand({
           const minutesLeft = Math.round((expiresAt.getTime() - Date.now()) / 60000);
           console.log(`  Expires in: ${minutesLeft} minutes`);
         }
+      } else {
+        const url = usageEndpoint(config.baseUrl, token);
+        try {
+          const response = await requestJson<AccountBalanceResponse | QuotaResponse>(config, { url });
+          renderUsage(response, config, token);
+        } catch (e) {
+          console.log(`  Quota fetch failed: ${(e as Error).message}`);
+        }
+        return;
       }
 
       // Fetch quota snapshot
@@ -64,7 +76,7 @@ export default defineCommand({
       try {
         const url = quotaEndpoint(config.baseUrl);
         const quota = await requestJson<QuotaResponse>(config, { url, method: 'GET' });
-        renderQuotaTable(quota.model_remains || [], config);
+        renderUsage(quota, config);
       } catch (e) {
         console.log(`  Quota fetch failed: ${(e as Error).message}`);
       }

--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -1,11 +1,11 @@
 import { defineCommand } from '../../command';
 import { requestJson } from '../../client/http';
-import { quotaEndpoint } from '../../client/endpoints';
+import { quotaEndpoint, usageEndpoint } from '../../client/endpoints';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
-import { renderQuotaTable } from '../../output/quota-table';
+import { renderUsage } from '../../output/usage';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { QuotaModelRemain } from '../../types/api';
+import type { AccountBalanceResponse, QuotaModelRemain } from '../../types/api';
 
 interface QuotaApiResponse {
   model_remains: QuotaModelRemain[];
@@ -25,10 +25,23 @@ export default defineCommand({
       return;
     }
 
+    const format = detectOutputFormat(flags.output as string | undefined);
+    const apiKey = config.apiKey || config.fileApiKey;
+
+    if (apiKey && apiKey.startsWith('sk-api-')) {
+      const url = usageEndpoint(config.baseUrl, apiKey);
+      const response = await requestJson<AccountBalanceResponse>(config, { url });
+      if (format !== 'text') {
+        console.log(formatOutput(response, format));
+        return;
+      }
+      renderUsage(response, config, apiKey);
+      return;
+    }
+
     const url = quotaEndpoint(config.baseUrl);
     const response = await requestJson<QuotaApiResponse>(config, { url });
     const models = response.model_remains || [];
-    const format = detectOutputFormat(flags.output as string | undefined);
 
     if (format !== 'text') {
       console.log(formatOutput(response, format));
@@ -43,6 +56,6 @@ export default defineCommand({
       return;
     }
 
-    renderQuotaTable(models, config);
+    renderUsage(response, config);
   },
 });

--- a/src/config/detect-region.ts
+++ b/src/config/detect-region.ts
@@ -1,15 +1,10 @@
-import { REGIONS, type Region } from "./schema";
-import { readConfigFile, writeConfigFile } from "./loader";
-import { CLIError } from "../errors/base";
-import { ExitCode } from "../errors/codes";
-
-const QUOTA_PATH = "/v1/token_plan/remains";
+import { REGIONS, type Region } from './schema';
+import { readConfigFile, writeConfigFile } from './loader';
+import { CLIError } from '../errors/base';
+import { ExitCode } from '../errors/codes';
+import { usageEndpoint } from '../client/endpoints';
 
 type ProbeResult = "authorized" | "unauthorized" | "unreachable" | "inconclusive";
-
-function quotaUrl(region: Region): string {
-  return REGIONS[region] + QUOTA_PATH;
-}
 
 async function probeRegion(
   region: Region,
@@ -31,7 +26,7 @@ async function probeRegion(
   for (const authHeader of authHeaders) {
     let res: Response;
     try {
-      res = await fetch(quotaUrl(region), {
+      res = await fetch(usageEndpoint(REGIONS[region], apiKey), {
         headers: { ...authHeader, "Content-Type": "application/json" },
         signal: AbortSignal.timeout(timeoutMs),
       });
@@ -74,12 +69,15 @@ export async function detectRegion(apiKey: string): Promise<Region> {
   const match = results.find((r) => r.result === "authorized");
   if (!match) {
     process.stderr.write(" failed\n");
+    const authHint = apiKey.startsWith('sk-api-')
+      ? 'No credentials were changed. Check that the key is valid and belongs to an API secret key.'
+      : 'No credentials were changed. Check that the key is valid and belongs to a Token Plan.';
 
     if (results.every((r) => r.result === "unauthorized")) {
       throw new CLIError(
         "API key was rejected by all regions.",
         ExitCode.AUTH,
-        "No credentials were changed. Check that the key is valid and belongs to a Token Plan.",
+        authHint,
       );
     }
 

--- a/src/output/balance.ts
+++ b/src/output/balance.ts
@@ -1,0 +1,19 @@
+import type { Config } from '../config/schema';
+import type { AccountBalanceResponse } from '../types/api';
+
+function formatFlag(value: boolean): string {
+  return value ? 'on' : 'off';
+}
+
+export function renderBalanceSummary(balance: AccountBalanceResponse, _config: Config): void {
+  console.log('Account Balance:');
+  console.log(`  Available: ${balance.available_amount}`);
+  console.log(`  Cash:      ${balance.cash_balance}`);
+  console.log(`  Voucher:   ${balance.voucher_balance}`);
+  console.log(`  Credit:    ${balance.credit_balance}`);
+  console.log(`  Owed:      ${balance.owed_amount}`);
+  console.log(`  Alert:     ${formatFlag(balance.balance_alert_switch)}`);
+  if (balance.balance_alert_threshold) {
+    console.log(`  Threshold: ${balance.balance_alert_threshold}`);
+  }
+}

--- a/src/output/usage.ts
+++ b/src/output/usage.ts
@@ -1,0 +1,18 @@
+import type { Config } from '../config/schema';
+import { isSecretApiKey } from '../client/endpoints';
+import type { AccountBalanceResponse, QuotaResponse } from '../types/api';
+import { renderBalanceSummary } from './balance';
+import { renderQuotaTable } from './quota-table';
+
+export function renderUsage(
+  response: QuotaResponse | AccountBalanceResponse,
+  config: Config,
+  apiKey?: string,
+): void {
+  if (apiKey && isSecretApiKey(apiKey)) {
+    renderBalanceSummary(response as AccountBalanceResponse, config);
+    return;
+  }
+
+  renderQuotaTable((response as QuotaResponse).model_remains || [], config);
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -336,6 +336,17 @@ export interface QuotaResponse {
   model_remains: QuotaModelRemain[];
 }
 
+export interface AccountBalanceResponse {
+  available_amount: string;
+  cash_balance: string;
+  voucher_balance: string;
+  credit_balance: string;
+  owed_amount: string;
+  balance_alert_switch: boolean;
+  balance_alert_threshold: string;
+  base_resp: BaseResp;
+}
+
 export interface QuotaModelRemain {
   model_name: string;
   start_time: number;

--- a/test/auth/timeout-fix.test.ts
+++ b/test/auth/timeout-fix.test.ts
@@ -18,10 +18,10 @@ import { CLIError } from '../../src/errors/base';
 import { ExitCode } from '../../src/errors/codes';
 
 // ---------------------------------------------------------------------------
-// Bug 1 — detect-region probes both Bearer and x-api-key auth styles
+// Bug 1 — detect-region probes the correct usage endpoint for each key type
 // ---------------------------------------------------------------------------
 
-describe('detect-region: probeRegion auth style fallback', () => {
+describe('detect-region: usage endpoint selection', () => {
   let server: MockServer;
 
   afterEach(() => server?.close());
@@ -46,6 +46,32 @@ describe('detect-region: probeRegion auth style fallback', () => {
     try {
       const { detectRegion } = await import('../../src/config/detect-region');
       const region = await detectRegion('bearer-only-key');
+      expect(region).toBe('global');
+    } finally {
+      (REGIONS as Record<string, string>).global = origGlobal;
+    }
+  });
+
+  it('uses account/query_balance for sk-api keys', async () => {
+    server = createMockServer({
+      routes: {
+        '/account/query_balance': (req) => {
+          if (req.headers.get('Authorization') === 'Bearer sk-api-secret-key') {
+            return jsonResponse({ base_resp: { status_code: 0 }, available_amount: '1' });
+          }
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        },
+        '/v1/token_plan/remains': () => jsonResponse({ error: 'should not be called' }, 500),
+      },
+    });
+
+    const { REGIONS } = await import('../../src/config/schema');
+    const origGlobal = REGIONS.global;
+    (REGIONS as Record<string, string>).global = server.url;
+
+    try {
+      const { detectRegion } = await import('../../src/config/detect-region');
+      const region = await detectRegion('sk-api-secret-key');
       expect(region).toBe('global');
     } finally {
       (REGIONS as Record<string, string>).global = origGlobal;

--- a/test/client/endpoints.test.ts
+++ b/test/client/endpoints.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { fileUploadEndpoint, quotaEndpoint } from '../../src/client/endpoints';
+import { fileUploadEndpoint, quotaEndpoint, usageEndpoint } from '../../src/client/endpoints';
 
 describe('quotaEndpoint', () => {
   it('uses token_plan/remains for global', () => {
@@ -18,5 +18,15 @@ describe('quotaEndpoint', () => {
 describe('fileUploadEndpoint', () => {
   it('uses the documented file upload path', () => {
     expect(fileUploadEndpoint('https://api.minimax.io')).toBe('https://api.minimax.io/v1/files/upload');
+  });
+});
+
+describe('usageEndpoint', () => {
+  it('uses token_plan/remains for normal api keys', () => {
+    expect(usageEndpoint('https://api.minimax.io', 'sk-abc')).toBe('https://api.minimax.io/v1/token_plan/remains');
+  });
+
+  it('uses account/query_balance for secret api keys', () => {
+    expect(usageEndpoint('https://api.minimax.io', 'sk-api-abc')).toBe('https://api.minimax.io/account/query_balance');
   });
 });

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -119,6 +119,74 @@ describe('auth login command', () => {
     }
   });
 
+  it('uses account/query_balance for sk-api keys', async () => {
+    let balanceRequests = 0;
+    server = createMockServer({
+      routes: {
+        '/account/query_balance': (req) => {
+          balanceRequests += 1;
+          if (req.headers.get('Authorization') === 'Bearer sk-api-secret-key') {
+            return jsonResponse({
+              available_amount: '98.00',
+              cash_balance: '0.00',
+              voucher_balance: '98.00',
+              credit_balance: '0.00',
+              owed_amount: '0.00',
+              balance_alert_switch: false,
+              balance_alert_threshold: '',
+              base_resp: { status_code: 0, status_msg: 'success' },
+            });
+          }
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        },
+      },
+    });
+
+    configDir = mkdtempSync(join(tmpdir(), 'mmx-region-login-'));
+    process.env.MMX_CONFIG_DIR = configDir;
+
+    const originalGlobal = REGIONS.global;
+    (REGIONS as Record<string, string>).global = server.url;
+
+    try {
+      await loginCommand.execute(
+        {
+          region: 'global',
+          baseUrl: originalGlobal,
+          output: 'text',
+          timeout: 1,
+          verbose: false,
+          quiet: true,
+          noColor: true,
+          yes: false,
+          dryRun: false,
+          nonInteractive: true,
+          async: false,
+        },
+        {
+          apiKey: 'sk-api-secret-key',
+          region: 'global',
+          quiet: true,
+          verbose: false,
+          noColor: true,
+          yes: false,
+          dryRun: false,
+          help: false,
+          nonInteractive: true,
+          async: false,
+        },
+      );
+
+      expect(balanceRequests).toBeGreaterThan(0);
+      expect(readConfigFile()).toMatchObject({
+        api_key: 'sk-api-secret-key',
+        region: 'global',
+      });
+    } finally {
+      (REGIONS as Record<string, string>).global = originalGlobal;
+    }
+  });
+
   it('does not save an explicitly selected region when authentication is rejected', async () => {
     server = createMockServer({
       routes: {

--- a/test/commands/auth/status.test.ts
+++ b/test/commands/auth/status.test.ts
@@ -1,12 +1,28 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { default as statusCommand } from '../../../src/commands/auth/status';
 
 describe('auth status command', () => {
+  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+  let configDir: string | undefined;
+
+  afterEach(() => {
+    if (configDir) rmSync(configDir, { recursive: true, force: true });
+    if (originalConfigDir === undefined) delete process.env.MMX_CONFIG_DIR;
+    else process.env.MMX_CONFIG_DIR = originalConfigDir;
+    configDir = undefined;
+  });
+
   it('has correct name', () => {
     expect(statusCommand.name).toBe('auth status');
   });
 
   it('shows not authenticated when no credentials', async () => {
+    configDir = mkdtempSync(join(tmpdir(), 'mmx-status-test-'));
+    process.env.MMX_CONFIG_DIR = configDir;
+
     const config = {
       region: 'global' as const,
       baseUrl: 'https://api.mmx.io',

--- a/test/commands/quota/show.test.ts
+++ b/test/commands/quota/show.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'bun:test';
+import { afterEach, describe, it, expect } from 'bun:test';
 import { default as showCommand } from '../../../src/commands/quota/show';
+import { createMockServer, jsonResponse, type MockServer } from '../../helpers/mock-server';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const baseConfig = {
   apiKey: 'test-key',
@@ -17,6 +21,7 @@ const baseConfig = {
 };
 
 const baseFlags = {
+  output: 'text' as const,
   quiet: false,
   verbose: false,
   noColor: true,
@@ -28,6 +33,16 @@ const baseFlags = {
 };
 
 describe('quota show command', () => {
+  let server: MockServer | undefined;
+  const originalConfigDir = process.env.MMX_CONFIG_DIR;
+
+  afterEach(() => {
+    server?.close();
+    if (originalConfigDir === undefined) delete process.env.MMX_CONFIG_DIR;
+    else process.env.MMX_CONFIG_DIR = originalConfigDir;
+    server = undefined;
+  });
+
   it('has correct name', () => {
     expect(showCommand.name).toBe('quota show');
   });
@@ -44,6 +59,52 @@ describe('quota show command', () => {
       expect(captured).toContain('Would fetch quota');
     } finally {
       console.log = origLog;
+    }
+  });
+
+  it('uses account/query_balance for sk-api keys', async () => {
+    server = createMockServer({
+      routes: {
+        '/account/query_balance': (req) => {
+          if (req.headers.get('Authorization') === 'Bearer sk-api-secret-key') {
+            return jsonResponse({
+              available_amount: '98.00',
+              cash_balance: '0.00',
+              voucher_balance: '98.00',
+              credit_balance: '0.00',
+              owed_amount: '0.00',
+              balance_alert_switch: false,
+              balance_alert_threshold: '',
+              base_resp: { status_code: 0, status_msg: 'success' },
+            });
+          }
+          return jsonResponse({ error: 'unauthorized' }, 401);
+        },
+      },
+    });
+
+    const configDir = mkdtempSync(join(tmpdir(), 'mmx-quota-balance-'));
+    process.env.MMX_CONFIG_DIR = configDir;
+    const origLog = console.log;
+
+    try {
+      const output: string[] = [];
+      console.log = (msg: string) => { output.push(msg); };
+
+      await showCommand.execute(
+        {
+          ...baseConfig,
+          apiKey: 'sk-api-secret-key',
+          baseUrl: server.url,
+        },
+        { ...baseFlags, output: 'text' as const },
+      );
+
+      expect(output.join('\n')).toContain('Account Balance:');
+      expect(output.join('\n')).toContain('98.00');
+    } finally {
+      console.log = origLog;
+      rmSync(configDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- route `sk-api-` secret keys to `/account/query_balance` instead of Token Plan remains
- keep Token Plan keys rendering the existing quota progress bars
- add balance text rendering for secret-key usage surfaces
- update region detection, login validation, auth status, and quota show tests

## Validation
- `bun run lint` (passes with existing warnings in `test/sdk/speech.test.ts` and `test/sdk/video.test.ts`)
- `bun test test/client/endpoints.test.ts test/auth/timeout-fix.test.ts test/commands/auth/login.test.ts test/commands/quota/show.test.ts test/commands/auth/status.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788171895&installation_model_id=427615&pr_number=216&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F216&signature=fddcd3d65569ae58f15fa33fc9faee1ea9cd9497f1249f747e75a47cd1a6be95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->