### PR TITLE
Add Video Generation V2 task management

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -30,6 +30,14 @@ export function videoTaskV2Endpoint(baseUrl: string, taskId: string): string {
   return `${baseUrl}/v2/query/video_generation/${taskId}`;
 }
 
+export function videoTaskV2ListEndpoint(baseUrl: string): string {
+  return `${baseUrl}/v2/query/video_generation`;
+}
+
+export function videoTaskV2DeleteEndpoint(baseUrl: string, taskId: string): string {
+  return `${baseUrl}/v2/video_generation/${taskId}`;
+}
+
 export function fileRetrieveEndpoint(baseUrl: string, fileId: string): string {
   return `${baseUrl}/v1/files/retrieve?file_id=${fileId}`;
 }

--- a/src/commands/video/task-delete.ts
+++ b/src/commands/video/task-delete.ts
@@ -1,0 +1,52 @@
+import { defineCommand } from '../../command';
+import { CLIError } from '../../errors/base';
+import { ExitCode } from '../../errors/codes';
+import { requestJson } from '../../client/http';
+import { videoTaskV2DeleteEndpoint } from '../../client/endpoints';
+import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import type { Config } from '../../config/schema';
+import type { GlobalFlags } from '../../types/flags';
+import type { VideoV2TaskDeleteResponse } from '../../types/api';
+
+export default defineCommand({
+  name: 'video task delete',
+  description: 'Delete a Video Generation V2 task',
+  apiDocs: '/docs/api-reference/video-generation-v2-delete',
+  usage: 'mmx video task delete --task-id <id>',
+  options: [
+    { flag: '--task-id <id>', description: 'Video Generation V2 task ID', required: true },
+  ],
+  examples: [
+    'mmx video task delete --task-id 424010985738629',
+  ],
+  async run(config: Config, flags: GlobalFlags) {
+    const taskId = flags.taskId as string | undefined;
+    if (!taskId) {
+      throw new CLIError(
+        '--task-id is required.',
+        ExitCode.USAGE,
+        'mmx video task delete --task-id <id>',
+      );
+    }
+
+    const format = detectOutputFormat(config.output);
+
+    if (config.dryRun) {
+      process.stdout.write(formatOutput({ request: { delete_video_task: taskId } }, format) + '\n');
+      return;
+    }
+
+    const url = videoTaskV2DeleteEndpoint(config.baseUrl, taskId);
+    const response = await requestJson<VideoV2TaskDeleteResponse>(config, {
+      url,
+      method: 'DELETE',
+    });
+
+    if (config.quiet) {
+      process.stdout.write(`${response.status}\n`);
+      return;
+    }
+
+    process.stdout.write(formatOutput(response, format) + '\n');
+  },
+});

--- a/src/commands/video/task-list.ts
+++ b/src/commands/video/task-list.ts
@@ -1,0 +1,66 @@
+import { defineCommand } from '../../command';
+import { requestJson } from '../../client/http';
+import { videoTaskV2ListEndpoint } from '../../client/endpoints';
+import { formatOutput, detectOutputFormat } from '../../output/formatter';
+import type { Config } from '../../config/schema';
+import type { GlobalFlags } from '../../types/flags';
+import type { VideoV2TaskListResponse } from '../../types/api';
+import { VIDEO_V2_MODEL } from '../../video/v2';
+
+export default defineCommand({
+  name: 'video task list',
+  description: 'List Video Generation V2 tasks',
+  apiDocs: '/docs/api-reference/video-generation-v2-list',
+  usage: 'mmx video task list [flags]',
+  options: [
+    { flag: '--page-num <number>', description: 'Page number to request', type: 'number' },
+    { flag: '--page-size <number>', description: 'Page size to request', type: 'number' },
+    { flag: '--status <status>', description: 'Filter by task status' },
+    { flag: '--task-id <id>', description: 'Filter by task ID; repeatable', type: 'array' },
+    { flag: '--task-type <type>', description: 'Filter by task type' },
+  ],
+  examples: [
+    'mmx video task list --output json',
+    'mmx video task list --status succeeded --page-size 20',
+  ],
+  async run(config: Config, flags: GlobalFlags) {
+    const format = detectOutputFormat(config.output);
+    const url = new URL(videoTaskV2ListEndpoint(config.baseUrl));
+
+    if (flags.pageNum !== undefined) url.searchParams.set('page_num', String(flags.pageNum));
+    if (flags.pageSize !== undefined) url.searchParams.set('page_size', String(flags.pageSize));
+    if (flags.status) url.searchParams.set('filter.status', String(flags.status));
+    const taskIds = flags.taskId as string[] | undefined;
+    if (taskIds?.length) url.searchParams.set('filter.task_ids', taskIds.join(','));
+    url.searchParams.set('filter.model', VIDEO_V2_MODEL);
+    if (flags.taskType) url.searchParams.set('filter.task_type', String(flags.taskType));
+
+    if (config.dryRun) {
+      process.stdout.write(formatOutput({ request: { url: url.toString() } }, format) + '\n');
+      return;
+    }
+
+    const response = await requestJson<VideoV2TaskListResponse>(config, { url: url.toString() });
+
+    if (format !== 'text') {
+      process.stdout.write(formatOutput(response, format) + '\n');
+      return;
+    }
+
+    if (!response.items || response.items.length === 0) {
+      process.stdout.write('No video tasks found.\n');
+      return;
+    }
+
+    const tableData = response.items.map(task => ({
+      ID: task.id,
+      MODEL: task.model,
+      STATUS: task.status,
+      RESOLUTION: task.resolution ?? '',
+      DURATION: task.duration ?? '',
+    }));
+
+    const { formatTable } = await import('../../output/text');
+    process.stdout.write(formatTable(tableData) + '\n');
+  },
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,6 +14,8 @@ import speechVoices from './commands/speech/voices';
 import imageGenerate from './commands/image/generate';
 import videoGenerate from './commands/video/generate';
 import videoTaskGet from './commands/video/task-get';
+import videoTaskList from './commands/video/task-list';
+import videoTaskDelete from './commands/video/task-delete';
 import videoDownload from './commands/video/download';
 import musicGenerate from './commands/music/generate';
 import musicCover from './commands/music/cover';
@@ -293,6 +295,8 @@ export const registry = new CommandRegistry({
   'image generate':    imageGenerate,
   'video generate':    videoGenerate,
   'video task get':    videoTaskGet,
+  'video task list':   videoTaskList,
+  'video task delete': videoTaskDelete,
   'video download':    videoDownload,
   'music generate':    musicGenerate,
   'music cover':       musicCover,

--- a/src/sdk/video/index.ts
+++ b/src/sdk/video/index.ts
@@ -4,12 +4,16 @@ import {
   videoGenerateEndpoint,
   videoGenerateV2Endpoint,
   videoTaskEndpoint,
+  videoTaskV2DeleteEndpoint,
   videoTaskV2Endpoint,
+  videoTaskV2ListEndpoint,
 } from "../../client/endpoints";
 import {
   FileRetrieveResponse,
   VideoRequest,
   VideoTaskResponse,
+  VideoV2TaskDeleteResponse,
+  VideoV2TaskListResponse,
   VideoV2Request,
   VideoV2Response,
   VideoV2Task,
@@ -47,6 +51,14 @@ export type VideoAsyncGenerateRequest = VideoGenerateRequest & {
 export interface VideoDownloadRequest {
   fileId: string;
   outPath: string;
+}
+
+export interface VideoV2ListTasksRequest {
+  pageNum?: number;
+  pageSize?: number;
+  status?: string;
+  taskIds?: string[];
+  taskType?: string;
 }
 
 export class VideoSDK extends Client {
@@ -103,6 +115,23 @@ export class VideoSDK extends Client {
 
     const url = videoTaskEndpoint(this.config.baseUrl, taskId);
     return await this.requestJson<VideoTaskResponse>({ url });
+  }
+
+  async listTasks(request: VideoV2ListTasksRequest = {}): Promise<VideoV2TaskListResponse> {
+    const url = new URL(videoTaskV2ListEndpoint(this.config.baseUrl));
+    if (request.pageNum !== undefined) url.searchParams.set('page_num', String(request.pageNum));
+    if (request.pageSize !== undefined) url.searchParams.set('page_size', String(request.pageSize));
+    if (request.status) url.searchParams.set('filter.status', request.status);
+    if (request.taskIds?.length) url.searchParams.set('filter.task_ids', request.taskIds.join(','));
+    url.searchParams.set('filter.model', VIDEO_V2_MODEL);
+    if (request.taskType) url.searchParams.set('filter.task_type', request.taskType);
+
+    return await this.requestJson<VideoV2TaskListResponse>({ url: url.toString() });
+  }
+
+  async deleteTask({taskId}: {taskId: string}): Promise<VideoV2TaskDeleteResponse> {
+    const url = videoTaskV2DeleteEndpoint(this.config.baseUrl, taskId);
+    return await this.requestJson<VideoV2TaskDeleteResponse>({ url, method: 'DELETE' });
   }
 
   async download(request: VideoDownloadRequest) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -271,10 +271,22 @@ export interface VideoV2Task {
   };
   ratio?: string;
   task_type?: string;
+  modality?: string;
 }
 
 export interface VideoV2TaskResponse {
   task: VideoV2Task;
+}
+
+export interface VideoV2TaskListResponse {
+  items: VideoV2Task[];
+  total: number;
+}
+
+export interface VideoV2TaskDeleteResponse {
+  task_id: string;
+  action: string;
+  status: string;
 }
 
 // ---- Music ----

--- a/test/commands/aliases.test.ts
+++ b/test/commands/aliases.test.ts
@@ -26,6 +26,12 @@ describe('command aliases', () => {
     expect(registry.resolve(['file', 'list']).command.name).toBe('file list');
     expect(registry.resolve(['file', 'delete']).command.name).toBe('file delete');
   });
+
+  it('resolves video task management commands', () => {
+    expect(registry.resolve(['video', 'task', 'get']).command.name).toBe('video task get');
+    expect(registry.resolve(['video', 'task', 'list']).command.name).toBe('video task list');
+    expect(registry.resolve(['video', 'task', 'delete']).command.name).toBe('video task delete');
+  });
 });
 
 describe('text chat --prompt alias', () => {

--- a/test/commands/video/task-delete.test.ts
+++ b/test/commands/video/task-delete.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { default as taskDeleteCommand } from '../../../src/commands/video/task-delete';
+import { createMockServer, jsonResponse, type MockServer } from '../../helpers/mock-server';
+import type { Config } from '../../../src/config/schema';
+import type { GlobalFlags } from '../../../src/types/flags';
+
+const baseConfig: Config = {
+  apiKey: 'test-key',
+  region: 'global',
+  baseUrl: 'https://api.mmx.io',
+  output: 'json',
+  timeout: 10,
+  verbose: false,
+  quiet: false,
+  noColor: true,
+  yes: false,
+  dryRun: false,
+  nonInteractive: true,
+  async: false,
+};
+
+const baseFlags: GlobalFlags = {
+  quiet: false,
+  verbose: false,
+  noColor: true,
+  yes: false,
+  dryRun: false,
+  help: false,
+  nonInteractive: true,
+  async: false,
+};
+
+describe('video task delete command', () => {
+  let server: MockServer;
+
+  afterEach(() => {
+    server?.close();
+  });
+
+  it('requires task-id', async () => {
+    await expect(taskDeleteCommand.execute(baseConfig, baseFlags))
+      .rejects.toThrow('--task-id is required');
+  });
+
+  it('deletes a Video Generation V2 task', async () => {
+    let method = '';
+    server = createMockServer({
+      routes: {
+        '/v2/video_generation/h3-123': (req) => {
+          method = req.method;
+          return jsonResponse({ task_id: 'h3-123', action: 'delete', status: 'deleted' });
+        },
+      },
+    });
+
+    let output = '';
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      output += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await taskDeleteCommand.execute(
+        { ...baseConfig, baseUrl: server.url },
+        { ...baseFlags, taskId: 'h3-123' },
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    expect(method).toBe('DELETE');
+    expect(JSON.parse(output)).toEqual({
+      task_id: 'h3-123',
+      action: 'delete',
+      status: 'deleted',
+    });
+  });
+});

--- a/test/commands/video/task-list.test.ts
+++ b/test/commands/video/task-list.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { default as taskListCommand } from '../../../src/commands/video/task-list';
+import { createMockServer, jsonResponse, type MockServer } from '../../helpers/mock-server';
+import type { Config } from '../../../src/config/schema';
+import type { GlobalFlags } from '../../../src/types/flags';
+
+const baseConfig: Config = {
+  apiKey: 'test-key',
+  region: 'global',
+  baseUrl: 'https://api.mmx.io',
+  output: 'json',
+  timeout: 10,
+  verbose: false,
+  quiet: false,
+  noColor: true,
+  yes: false,
+  dryRun: false,
+  nonInteractive: true,
+  async: false,
+};
+
+const baseFlags: GlobalFlags = {
+  quiet: false,
+  verbose: false,
+  noColor: true,
+  yes: false,
+  dryRun: false,
+  help: false,
+  nonInteractive: true,
+  async: false,
+};
+
+describe('video task list command', () => {
+  let server: MockServer;
+
+  afterEach(() => {
+    server?.close();
+  });
+
+  it('lists Video Generation V2 tasks with filters', async () => {
+    let requestedUrl = '';
+    server = createMockServer({
+      routes: {
+        '/v2/query/video_generation': (req) => {
+          requestedUrl = req.url;
+          return jsonResponse({
+            items: [{ id: 'h3-123', model: 'MiniMax-H3', status: 'succeeded' }],
+            total: 1,
+          });
+        },
+      },
+    });
+
+    let output = '';
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      output += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await taskListCommand.execute(
+        { ...baseConfig, baseUrl: server.url },
+        {
+          ...baseFlags,
+          pageNum: 1,
+          pageSize: 20,
+          status: 'succeeded',
+          taskId: ['h3-123'],
+          taskType: 'text_to_video',
+        },
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const url = new URL(requestedUrl);
+    expect(url.searchParams.get('page_num')).toBe('1');
+    expect(url.searchParams.get('page_size')).toBe('20');
+    expect(url.searchParams.get('filter.status')).toBe('succeeded');
+    expect(url.searchParams.get('filter.task_ids')).toBe('h3-123');
+    expect(url.searchParams.get('filter.model')).toBe('MiniMax-H3');
+    expect(url.searchParams.get('filter.task_type')).toBe('text_to_video');
+    expect(JSON.parse(output).total).toBe(1);
+  });
+});

--- a/test/sdk/video.test.ts
+++ b/test/sdk/video.test.ts
@@ -145,6 +145,65 @@ describe('MiniMaxSDK.video', () => {
     expect(result.status).toBe('succeeded');
   });
 
+  it('should list MiniMax-H3 tasks from Video Generation V2', async () => {
+    let requestedUrl = '';
+    server = createMockServer({
+      routes: {
+        '/v2/query/video_generation': (req) => {
+          requestedUrl = req.url;
+          return jsonResponse({
+            items: [{ id: 'h3-123', model: 'MiniMax-H3', status: 'succeeded' }],
+            total: 1,
+          });
+        },
+      },
+    });
+
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+
+    const result = await sdk.video.listTasks({
+      pageNum: 2,
+      pageSize: 10,
+      status: 'succeeded',
+      taskIds: ['h3-123'],
+      taskType: 'text_to_video',
+    });
+
+    const url = new URL(requestedUrl);
+    expect(url.searchParams.get('page_num')).toBe('2');
+    expect(url.searchParams.get('page_size')).toBe('10');
+    expect(url.searchParams.get('filter.status')).toBe('succeeded');
+    expect(url.searchParams.get('filter.task_ids')).toBe('h3-123');
+    expect(url.searchParams.get('filter.model')).toBe('MiniMax-H3');
+    expect(url.searchParams.get('filter.task_type')).toBe('text_to_video');
+    expect(result.total).toBe(1);
+  });
+
+  it('should delete a MiniMax-H3 task from Video Generation V2', async () => {
+    let method = '';
+    server = createMockServer({
+      routes: {
+        '/v2/video_generation/h3-123': (req) => {
+          method = req.method;
+          return jsonResponse({ task_id: 'h3-123', action: 'delete', status: 'deleted' });
+        },
+      },
+    });
+
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+
+    const result = await sdk.video.deleteTask({ taskId: 'h3-123' });
+
+    expect(method).toBe('DELETE');
+    expect(result).toEqual({ task_id: 'h3-123', action: 'delete', status: 'deleted' });
+  });
+
   it('should poll a MiniMax-H3 task from running to succeeded', async () => {
     let pollCount = 0;
     server = createMockServer({


### PR DESCRIPTION
Reason: Refresh MiniMax video task support for the Video Generation V2 API.

Changes:
- Added Video Generation V2 list and delete endpoints.
- Added SDK helpers for listing and deleting video tasks.
- Added CLI commands for `video task list` and `video task delete`.
- Added focused SDK, command, and registry tests for the new task APIs.

Checks:
- `bun run typecheck`
- `bun test test/sdk/video.test.ts test/commands/video/task-list.test.ts test/commands/video/task-delete.test.ts test/commands/aliases.test.ts`
- `bun run lint` (passes with one pre-existing warning in `test/sdk/speech.test.ts`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200308&installation_model_id=427615&pr_number=219&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F219&signature=4b4e0bee881239fe6ad2041fd6c73ee364d435d9490516a825ae2dc1d62a298f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->