### PR TITLE
fix(registry): dedupe getAllCommands so aliased commands are not exported twice

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -58,9 +58,17 @@ class CommandRegistry {
   }
 
   getAllCommands(): Command[] {
+    // Aliases register the same Command object under more than one path
+    // ('speech generate' -> speechSynthesize, 'search web' -> searchQuery), so
+    // a plain traversal yields it once per alias. Dedupe by identity: callers
+    // want the set of distinct commands, not the set of invocation paths.
+    const seen = new Set<Command>();
     const commands: Command[] = [];
     const traverse = (node: CommandNode) => {
-      if (node.command) commands.push(node.command);
+      if (node.command && !seen.has(node.command)) {
+        seen.add(node.command);
+        commands.push(node.command);
+      }
       for (const child of node.children.values()) {
         traverse(child);
       }


### PR DESCRIPTION
`config export-schema` currently emits **19 tool schemas with only 17 distinct names**:

```
$ mmx config export-schema | jq -r '.[].name' | sort | uniq -d
mmx_search_query
mmx_speech_synthesize
```

Duplicate function names are rejected by both the Anthropic and OpenAI tool APIs, so the exported schema cannot be handed to a model as-is without post-processing.

**Cause.** Two commands are registered under a second alias path:

```ts
'speech synthesize': speechSynthesize,
'speech generate':   speechSynthesize,   // same object
'search query':      searchQuery,
'search web':        searchQuery,        // same object
```

`CommandRegistry.getAllCommands()` walks the path trie and pushes `node.command` at every node that has one — so an aliased command is pushed once per path, not once per command. `export-schema` maps that list straight to `generateToolSchema`, and the duplicates land in the output.

**Fix.** Dedupe by object identity during the traversal. Callers of `getAllCommands` want the set of distinct commands, not the set of invocation paths.

**Verified locally** (`bun run src/main.ts`):

```
before   total entries: 19   unique names: 17   duplicates: {mmx_speech_synthesize: 2, mmx_search_query: 2}
after    total entries: 17   unique names: 17   duplicates: none
```

Alias routing is untouched — `mmx speech generate --help` and `mmx search web --help` both still resolve and exit 0. Only enumeration changes.

`bun test`: **385 pass / 8 fail**, identical to the baseline on a clean checkout with this change stashed. Those 8 appear to be network-dependent (one logs `Detecting region... failed`) and are unrelated.

Happy to add a regression test asserting `getAllCommands().length === new Set(getAllCommands()).size` if you'd like one — I left it out because the repo's registry tests looked deliberately light, but say the word.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788203611&installation_model_id=427615&pr_number=220&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F220&signature=22b701fcdab8e72368c56105a1ee574c30442c833ba4f81515e3ab8bab3fd217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->