### PR TITLE
Add speech voice clone and design commands

### DIFF
--- a/src/client/endpoints.ts
+++ b/src/client/endpoints.ts
@@ -10,6 +10,14 @@ export function voicesEndpoint(baseUrl: string): string {
   return `${baseUrl}/v1/get_voice`;
 }
 
+export function voiceCloneEndpoint(baseUrl: string): string {
+  return `${baseUrl}/v1/voice_clone`;
+}
+
+export function voiceDesignEndpoint(baseUrl: string): string {
+  return `${baseUrl}/v1/voice_design`;
+}
+
 export function imageEndpoint(baseUrl: string): string {
   return `${baseUrl}/v1/image_generation`;
 }

--- a/src/commands/speech/clone.ts
+++ b/src/commands/speech/clone.ts
@@ -6,7 +6,7 @@ import { ExitCode } from '../../errors/codes';
 import { detectOutputFormat, formatOutput } from '../../output/formatter';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { FileUploadResponse, VoiceCloneRequest, VoiceResponse } from '../../types/api';
+import type { FileUploadResponse, VoiceCloneRequest, VoiceCloneResponse } from '../../types/api';
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { basename, resolve } from 'path';
@@ -34,12 +34,13 @@ export default defineCommand({
   name: 'speech clone',
   description: 'Clone a voice from uploaded audio',
   apiDocs: '/docs/api-reference/voice-cloning-clone',
-  usage: 'mmx speech clone --file-id <id> --voice-id <id> [--model <model>]',
+  usage: 'mmx speech clone --file-id <id> --voice-id <id> [--text <text>] [--model <model>]',
   options: [
     { flag: '--file-id <id>', description: 'Uploaded clone audio file ID' },
     { flag: '--file <path>', description: 'Upload local clone audio before cloning' },
     { flag: '--voice-id <id>', description: 'Voice ID to create', required: true },
-    { flag: '--model <model>', description: 'Clone model (default: speech-2.8-hd)' },
+    { flag: '--text <text>', description: 'Optional preview text; enables model requirement' },
+    { flag: '--model <model>', description: 'Clone model (required with --text)' },
   ],
   examples: [
     'mmx file upload --file sample.wav --purpose voice_clone',
@@ -57,12 +58,17 @@ export default defineCommand({
     if (!fileId && !filePath) {
       throw new CLIError('--file-id or --file is required.', ExitCode.USAGE, 'mmx speech clone --file-id <id> --voice-id <id>');
     }
+    if (fileId && (!Number.isSafeInteger(Number(fileId)) || Number(fileId) <= 0)) {
+      throw new CLIError('--file-id must be a positive integer.', ExitCode.USAGE);
+    }
 
-    const model = (flags.model as string) || DEFAULT_VOICE_CLONE_MODEL;
+    const text = flags.text as string | undefined;
+    const model = (flags.model as string | undefined) || (text ? DEFAULT_VOICE_CLONE_MODEL : undefined);
     const body: VoiceCloneRequest = {
-      file_id: fileId || '<uploaded-file-id>',
+      file_id: fileId ? Number(fileId) : 0,
       voice_id: voiceId,
-      model,
+      ...(text ? { text } : {}),
+      ...(model ? { model } : {}),
     };
     const format = detectOutputFormat(config.output);
 
@@ -77,17 +83,17 @@ export default defineCommand({
     if (!fileId && filePath) {
       const upload = await uploadCloneAudio(config, filePath);
       fileId = upload.file.file_id;
-      body.file_id = fileId;
+      body.file_id = Number(fileId);
     }
 
-    const response = await requestJson<VoiceResponse>(config, {
+    const response = await requestJson<VoiceCloneResponse>(config, {
       url: voiceCloneEndpoint(config.baseUrl),
       method: 'POST',
       body,
     });
 
     if (config.quiet) {
-      process.stdout.write(response.voice_id + '\n');
+      process.stdout.write((response.demo_audio || '') + '\n');
       return;
     }
 

--- a/src/commands/speech/clone.ts
+++ b/src/commands/speech/clone.ts
@@ -1,0 +1,96 @@
+import { defineCommand } from '../../command';
+import { requestJson } from '../../client/http';
+import { fileUploadEndpoint, voiceCloneEndpoint } from '../../client/endpoints';
+import { CLIError } from '../../errors/base';
+import { ExitCode } from '../../errors/codes';
+import { detectOutputFormat, formatOutput } from '../../output/formatter';
+import type { Config } from '../../config/schema';
+import type { GlobalFlags } from '../../types/flags';
+import type { FileUploadResponse, VoiceCloneRequest, VoiceResponse } from '../../types/api';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { basename, resolve } from 'path';
+
+const DEFAULT_VOICE_CLONE_MODEL = 'speech-2.8-hd';
+
+async function uploadCloneAudio(config: Config, filePath: string): Promise<FileUploadResponse> {
+  const fullPath = resolve(filePath);
+  if (!existsSync(fullPath)) {
+    throw new CLIError(`File not found: ${fullPath}`, ExitCode.USAGE);
+  }
+
+  const formData = new FormData();
+  formData.append('file', new Blob([await readFile(fullPath)]), basename(fullPath));
+  formData.append('purpose', 'voice_clone');
+
+  return requestJson<FileUploadResponse>(config, {
+    url: fileUploadEndpoint(config.baseUrl),
+    method: 'POST',
+    body: formData,
+  });
+}
+
+export default defineCommand({
+  name: 'speech clone',
+  description: 'Clone a voice from uploaded audio',
+  apiDocs: '/docs/api-reference/voice-cloning-clone',
+  usage: 'mmx speech clone --file-id <id> --voice-id <id> [--model <model>]',
+  options: [
+    { flag: '--file-id <id>', description: 'Uploaded clone audio file ID' },
+    { flag: '--file <path>', description: 'Upload local clone audio before cloning' },
+    { flag: '--voice-id <id>', description: 'Voice ID to create', required: true },
+    { flag: '--model <model>', description: 'Clone model (default: speech-2.8-hd)' },
+  ],
+  examples: [
+    'mmx file upload --file sample.wav --purpose voice_clone',
+    'mmx speech clone --file-id 123 --voice-id my_voice',
+    'mmx speech clone --file sample.wav --voice-id my_voice --model speech-2.6-hd',
+  ],
+  async run(config: Config, flags: GlobalFlags) {
+    const voiceId = flags.voiceId as string | undefined;
+    const filePath = flags.file as string | undefined;
+    let fileId = flags.fileId as string | undefined;
+
+    if (!voiceId) {
+      throw new CLIError('--voice-id is required.', ExitCode.USAGE, 'mmx speech clone --file-id <id> --voice-id <id>');
+    }
+    if (!fileId && !filePath) {
+      throw new CLIError('--file-id or --file is required.', ExitCode.USAGE, 'mmx speech clone --file-id <id> --voice-id <id>');
+    }
+
+    const model = (flags.model as string) || DEFAULT_VOICE_CLONE_MODEL;
+    const body: VoiceCloneRequest = {
+      file_id: fileId || '<uploaded-file-id>',
+      voice_id: voiceId,
+      model,
+    };
+    const format = detectOutputFormat(config.output);
+
+    if (config.dryRun) {
+      const request = filePath
+        ? { upload: { file: resolve(filePath), purpose: 'voice_clone' }, clone: body }
+        : body;
+      process.stdout.write(formatOutput({ request }, format) + '\n');
+      return;
+    }
+
+    if (!fileId && filePath) {
+      const upload = await uploadCloneAudio(config, filePath);
+      fileId = upload.file.file_id;
+      body.file_id = fileId;
+    }
+
+    const response = await requestJson<VoiceResponse>(config, {
+      url: voiceCloneEndpoint(config.baseUrl),
+      method: 'POST',
+      body,
+    });
+
+    if (config.quiet) {
+      process.stdout.write(response.voice_id + '\n');
+      return;
+    }
+
+    process.stdout.write(formatOutput(response, format) + '\n');
+  },
+});

--- a/src/commands/speech/design.ts
+++ b/src/commands/speech/design.ts
@@ -1,0 +1,55 @@
+import { defineCommand } from '../../command';
+import { requestJson } from '../../client/http';
+import { voiceDesignEndpoint } from '../../client/endpoints';
+import { CLIError } from '../../errors/base';
+import { ExitCode } from '../../errors/codes';
+import { detectOutputFormat, dryRun, formatOutput } from '../../output/formatter';
+import type { Config } from '../../config/schema';
+import type { GlobalFlags } from '../../types/flags';
+import type { VoiceDesignRequest, VoiceResponse } from '../../types/api';
+
+export default defineCommand({
+  name: 'speech design',
+  description: 'Design a voice from a prompt',
+  apiDocs: '/docs/api-reference/voice-design-design',
+  usage: 'mmx speech design --prompt <text> --voice-id <id>',
+  options: [
+    { flag: '--prompt <text>', description: 'Voice design prompt', required: true },
+    { flag: '--voice-id <id>', description: 'Voice ID to create', required: true },
+  ],
+  examples: [
+    'mmx file upload --file prompt.wav --purpose prompt_audio',
+    'mmx speech design --prompt "Warm and clear narrator" --voice-id narrator_voice',
+  ],
+  async run(config: Config, flags: GlobalFlags) {
+    const prompt = flags.prompt as string | undefined;
+    const voiceId = flags.voiceId as string | undefined;
+
+    if (!prompt) {
+      throw new CLIError('--prompt is required.', ExitCode.USAGE, 'mmx speech design --prompt <text> --voice-id <id>');
+    }
+    if (!voiceId) {
+      throw new CLIError('--voice-id is required.', ExitCode.USAGE, 'mmx speech design --prompt <text> --voice-id <id>');
+    }
+
+    const body: VoiceDesignRequest = {
+      prompt,
+      voice_id: voiceId,
+    };
+
+    if (dryRun(config, body)) return;
+
+    const response = await requestJson<VoiceResponse>(config, {
+      url: voiceDesignEndpoint(config.baseUrl),
+      method: 'POST',
+      body,
+    });
+
+    if (config.quiet) {
+      process.stdout.write(response.voice_id + '\n');
+      return;
+    }
+
+    process.stdout.write(formatOutput(response, detectOutputFormat(config.output)) + '\n');
+  },
+});

--- a/src/commands/speech/design.ts
+++ b/src/commands/speech/design.ts
@@ -6,47 +6,50 @@ import { ExitCode } from '../../errors/codes';
 import { detectOutputFormat, dryRun, formatOutput } from '../../output/formatter';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
-import type { VoiceDesignRequest, VoiceResponse } from '../../types/api';
+import type { VoiceDesignRequest, VoiceDesignResponse } from '../../types/api';
 
 export default defineCommand({
   name: 'speech design',
   description: 'Design a voice from a prompt',
   apiDocs: '/docs/api-reference/voice-design-design',
-  usage: 'mmx speech design --prompt <text> --voice-id <id>',
+  usage: 'mmx speech design --prompt <text> --preview-text <text> [--voice-id <id>]',
   options: [
     { flag: '--prompt <text>', description: 'Voice design prompt', required: true },
-    { flag: '--voice-id <id>', description: 'Voice ID to create', required: true },
+    { flag: '--preview-text <text>', description: 'Text for the generated voice preview', required: true },
+    { flag: '--voice-id <id>', description: 'Optional voice ID to create' },
   ],
   examples: [
     'mmx file upload --file prompt.wav --purpose prompt_audio',
-    'mmx speech design --prompt "Warm and clear narrator" --voice-id narrator_voice',
+    'mmx speech design --prompt "Warm and clear narrator" --preview-text "Welcome to the show"',
   ],
   async run(config: Config, flags: GlobalFlags) {
     const prompt = flags.prompt as string | undefined;
+    const previewText = flags.previewText as string | undefined;
     const voiceId = flags.voiceId as string | undefined;
 
     if (!prompt) {
       throw new CLIError('--prompt is required.', ExitCode.USAGE, 'mmx speech design --prompt <text> --voice-id <id>');
     }
-    if (!voiceId) {
-      throw new CLIError('--voice-id is required.', ExitCode.USAGE, 'mmx speech design --prompt <text> --voice-id <id>');
+    if (!previewText) {
+      throw new CLIError('--preview-text is required.', ExitCode.USAGE, 'mmx speech design --prompt <text> --preview-text <text>');
     }
 
     const body: VoiceDesignRequest = {
       prompt,
-      voice_id: voiceId,
+      preview_text: previewText,
+      ...(voiceId ? { voice_id: voiceId } : {}),
     };
 
     if (dryRun(config, body)) return;
 
-    const response = await requestJson<VoiceResponse>(config, {
+    const response = await requestJson<VoiceDesignResponse>(config, {
       url: voiceDesignEndpoint(config.baseUrl),
       method: 'POST',
       body,
     });
 
     if (config.quiet) {
-      process.stdout.write(response.voice_id + '\n');
+      process.stdout.write((response.voice_id || '') + '\n');
       return;
     }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,6 +11,8 @@ import textChat from './commands/text/chat';
 import textRepl from './commands/text/repl';
 import speechSynthesize from './commands/speech/synthesize';
 import speechVoices from './commands/speech/voices';
+import speechClone from './commands/speech/clone';
+import speechDesign from './commands/speech/design';
 import imageGenerate from './commands/image/generate';
 import videoGenerate from './commands/video/generate';
 import videoTaskGet from './commands/video/task-get';
@@ -290,6 +292,8 @@ export const registry = new CommandRegistry({
   'speech synthesize': speechSynthesize,
   'speech generate':   speechSynthesize,
   'speech voices':     speechVoices,
+  'speech clone':      speechClone,
+  'speech design':     speechDesign,
   'image generate':    imageGenerate,
   'video generate':    videoGenerate,
   'video task get':    videoTaskGet,

--- a/src/sdk/speech/index.ts
+++ b/src/sdk/speech/index.ts
@@ -1,8 +1,9 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname, basename } from 'node:path';
 import { Client } from "../client";
-import { speechEndpoint, voicesEndpoint } from "../../client/endpoints";
-import { SpeechRequest, SpeechResponse, VoiceListResponse } from "../../types/api";
+import { fileUploadEndpoint, speechEndpoint, voiceCloneEndpoint, voiceDesignEndpoint, voicesEndpoint } from "../../client/endpoints";
+import { FileUploadResponse, SpeechRequest, SpeechResponse, VoiceCloneRequest, VoiceDesignRequest, VoiceListResponse, VoiceResponse } from "../../types/api";
 import { filterByLanguage } from "../../commands/speech/voices";
 import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
@@ -73,6 +74,47 @@ export class SpeechSDK extends Client {
     return voices;
   }
 
+  async uploadCloneAudio(filePath: string): Promise<FileUploadResponse> {
+    return this.uploadVoiceAudio(filePath, 'voice_clone');
+  }
+
+  async uploadPromptAudio(filePath: string): Promise<FileUploadResponse> {
+    return this.uploadVoiceAudio(filePath, 'prompt_audio');
+  }
+
+  async clone(request: VoiceCloneRequest): Promise<VoiceResponse> {
+    if (!request.file_id) {
+      throw new SDKError('file_id is required', ExitCode.USAGE);
+    }
+    if (!request.voice_id) {
+      throw new SDKError('voice_id is required', ExitCode.USAGE);
+    }
+    if (!request.model) {
+      throw new SDKError('model is required', ExitCode.USAGE);
+    }
+
+    return this.requestJson<VoiceResponse>({
+      url: voiceCloneEndpoint(this.config.baseUrl),
+      method: 'POST',
+      body: request,
+    });
+  }
+
+  async design(request: VoiceDesignRequest): Promise<VoiceResponse> {
+    if (!request.prompt) {
+      throw new SDKError('prompt is required', ExitCode.USAGE);
+    }
+    if (!request.voice_id) {
+      throw new SDKError('voice_id is required', ExitCode.USAGE);
+    }
+
+    return this.requestJson<VoiceResponse>({
+      url: voiceDesignEndpoint(this.config.baseUrl),
+      method: 'POST',
+      body: request,
+    });
+  }
+
   /**
    * Save synthesized speech audio to a file. Decodes the hex-encoded audio
    * from the API response and writes it to disk. Creates intermediate
@@ -123,5 +165,23 @@ export class SpeechSDK extends Client {
       },
       output_format: 'hex',
     }, params) as SpeechRequest;
+  }
+
+  private async uploadVoiceAudio(filePath: string, purpose: 'voice_clone' | 'prompt_audio'): Promise<FileUploadResponse> {
+    const fullPath = resolve(filePath);
+    if (!existsSync(fullPath)) {
+      throw new SDKError(`File not found: ${fullPath}`, ExitCode.USAGE);
+    }
+
+    const fileData = await readFile(fullPath);
+    const formData = new FormData();
+    formData.append('file', new Blob([fileData]), basename(fullPath));
+    formData.append('purpose', purpose);
+
+    return this.requestJson<FileUploadResponse>({
+      url: fileUploadEndpoint(this.config.baseUrl),
+      method: 'POST',
+      body: formData,
+    });
   }
 }

--- a/src/sdk/speech/index.ts
+++ b/src/sdk/speech/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve, dirname, basename } from 'node:path';
 import { Client } from "../client";
 import { fileUploadEndpoint, speechEndpoint, voiceCloneEndpoint, voiceDesignEndpoint, voicesEndpoint } from "../../client/endpoints";
-import { FileUploadResponse, SpeechRequest, SpeechResponse, VoiceCloneRequest, VoiceDesignRequest, VoiceListResponse, VoiceResponse } from "../../types/api";
+import { FileUploadResponse, SpeechRequest, SpeechResponse, VoiceCloneRequest, VoiceCloneResponse, VoiceDesignRequest, VoiceDesignResponse, VoiceListResponse } from "../../types/api";
 import { filterByLanguage } from "../../commands/speech/voices";
 import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
@@ -82,33 +82,33 @@ export class SpeechSDK extends Client {
     return this.uploadVoiceAudio(filePath, 'prompt_audio');
   }
 
-  async clone(request: VoiceCloneRequest): Promise<VoiceResponse> {
-    if (!request.file_id) {
-      throw new SDKError('file_id is required', ExitCode.USAGE);
+  async clone(request: VoiceCloneRequest): Promise<VoiceCloneResponse> {
+    if (!Number.isSafeInteger(request.file_id) || request.file_id <= 0) {
+      throw new SDKError('file_id must be a positive integer', ExitCode.USAGE);
     }
     if (!request.voice_id) {
       throw new SDKError('voice_id is required', ExitCode.USAGE);
     }
-    if (!request.model) {
-      throw new SDKError('model is required', ExitCode.USAGE);
+    if (request.text && !request.model) {
+      throw new SDKError('model is required when text is provided', ExitCode.USAGE);
     }
 
-    return this.requestJson<VoiceResponse>({
+    return this.requestJson<VoiceCloneResponse>({
       url: voiceCloneEndpoint(this.config.baseUrl),
       method: 'POST',
       body: request,
     });
   }
 
-  async design(request: VoiceDesignRequest): Promise<VoiceResponse> {
+  async design(request: VoiceDesignRequest): Promise<VoiceDesignResponse> {
     if (!request.prompt) {
       throw new SDKError('prompt is required', ExitCode.USAGE);
     }
-    if (!request.voice_id) {
-      throw new SDKError('voice_id is required', ExitCode.USAGE);
+    if (!request.preview_text) {
+      throw new SDKError('preview_text is required', ExitCode.USAGE);
     }
 
-    return this.requestJson<VoiceResponse>({
+    return this.requestJson<VoiceDesignResponse>({
       url: voiceDesignEndpoint(this.config.baseUrl),
       method: 'POST',
       body: request,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -143,18 +143,38 @@ export interface VoiceListResponse {
 }
 
 export interface VoiceCloneRequest {
-  file_id: string;
+  file_id: number;
   voice_id: string;
-  model: string;
+  clone_prompt?: {
+    prompt_audio?: number;
+    prompt_text?: string;
+  };
+  text?: string;
+  model?: string;
+  text_validation?: string;
+  accuracy?: number;
+  need_noise_reduction?: boolean;
+  need_volume_normalization?: boolean;
+  aigc_watermark?: boolean;
 }
 
 export interface VoiceDesignRequest {
   prompt: string;
-  voice_id: string;
+  preview_text: string;
+  voice_id?: string;
 }
 
-export interface VoiceResponse {
-  voice_id: string;
+export interface VoiceCloneResponse {
+  input_sensitive?: boolean;
+  input_sensitive_type?: number;
+  demo_audio?: string;
+  extra_info?: Record<string, unknown>;
+  base_resp: BaseResp;
+}
+
+export interface VoiceDesignResponse {
+  trial_audio?: string;
+  voice_id?: string;
   base_resp: BaseResp;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -142,6 +142,22 @@ export interface VoiceListResponse {
   base_resp: BaseResp;
 }
 
+export interface VoiceCloneRequest {
+  file_id: string;
+  voice_id: string;
+  model: string;
+}
+
+export interface VoiceDesignRequest {
+  prompt: string;
+  voice_id: string;
+}
+
+export interface VoiceResponse {
+  voice_id: string;
+  base_resp: BaseResp;
+}
+
 // ---- Image ----
 
 export interface ImageRequest {

--- a/test/commands/aliases.test.ts
+++ b/test/commands/aliases.test.ts
@@ -26,6 +26,11 @@ describe('command aliases', () => {
     expect(registry.resolve(['file', 'list']).command.name).toBe('file list');
     expect(registry.resolve(['file', 'delete']).command.name).toBe('file delete');
   });
+
+  it('resolves speech voice commands', () => {
+    expect(registry.resolve(['speech', 'clone']).command.name).toBe('speech clone');
+    expect(registry.resolve(['speech', 'design']).command.name).toBe('speech design');
+  });
 });
 
 describe('text chat --prompt alias', () => {

--- a/test/commands/speech/clone.test.ts
+++ b/test/commands/speech/clone.test.ts
@@ -58,16 +58,15 @@ describe('speech clone command', () => {
     const output = await captureStdout(async () => {
       await cloneCommand.execute(baseConfig, {
         ...baseFlags,
-        fileId: 'file-123',
+        fileId: '123',
         voiceId: 'my_voice',
       });
     });
 
     const parsed = JSON.parse(output);
     expect(parsed.request).toEqual({
-      file_id: 'file-123',
+      file_id: 123,
       voice_id: 'my_voice',
-      model: 'speech-2.8-hd',
     });
   });
 
@@ -84,9 +83,9 @@ describe('speech clone command', () => {
     const parsed = JSON.parse(output);
     expect(parsed.request.upload.purpose).toBe('voice_clone');
     expect(parsed.request.clone).toEqual({
-      file_id: '<uploaded-file-id>',
-      voice_id: 'my_voice',
-      model: 'speech-2.6-hd',
+        file_id: 0,
+        voice_id: 'my_voice',
+        model: 'speech-2.6-hd',
     });
   });
 });

--- a/test/commands/speech/clone.test.ts
+++ b/test/commands/speech/clone.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'bun:test';
+import { default as cloneCommand } from '../../../src/commands/speech/clone';
+
+const baseConfig = {
+  apiKey: 'test-key',
+  region: 'global' as const,
+  baseUrl: 'https://api.mmx.io',
+  output: 'json' as const,
+  timeout: 10,
+  verbose: false,
+  quiet: false,
+  noColor: true,
+  yes: false,
+  dryRun: true,
+  nonInteractive: true,
+  async: false,
+};
+
+const baseFlags = {
+  quiet: false,
+  verbose: false,
+  noColor: true,
+  yes: false,
+  dryRun: true,
+  help: false,
+  nonInteractive: true,
+  async: false,
+};
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stdout.write;
+  let output = '';
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+    return output;
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe('speech clone command', () => {
+  it('has correct name', () => {
+    expect(cloneCommand.name).toBe('speech clone');
+  });
+
+  it('requires clone input audio', async () => {
+    await expect(
+      cloneCommand.execute(baseConfig, { ...baseFlags, voiceId: 'my_voice' }),
+    ).rejects.toThrow('--file-id or --file is required');
+  });
+
+  it('builds clone request with the default HD model', async () => {
+    const output = await captureStdout(async () => {
+      await cloneCommand.execute(baseConfig, {
+        ...baseFlags,
+        fileId: 'file-123',
+        voiceId: 'my_voice',
+      });
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.request).toEqual({
+      file_id: 'file-123',
+      voice_id: 'my_voice',
+      model: 'speech-2.8-hd',
+    });
+  });
+
+  it('includes voice_clone upload purpose when a local file is used', async () => {
+    const output = await captureStdout(async () => {
+      await cloneCommand.execute(baseConfig, {
+        ...baseFlags,
+        file: 'sample.wav',
+        voiceId: 'my_voice',
+        model: 'speech-2.6-hd',
+      });
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.request.upload.purpose).toBe('voice_clone');
+    expect(parsed.request.clone).toEqual({
+      file_id: '<uploaded-file-id>',
+      voice_id: 'my_voice',
+      model: 'speech-2.6-hd',
+    });
+  });
+});

--- a/test/commands/speech/design.test.ts
+++ b/test/commands/speech/design.test.ts
@@ -34,7 +34,7 @@ describe('speech design command', () => {
 
   it('requires prompt', async () => {
     await expect(
-      designCommand.execute(baseConfig, { ...baseFlags, voiceId: 'designed_voice' }),
+      designCommand.execute(baseConfig, { ...baseFlags, previewText: 'Hello' }),
     ).rejects.toThrow('--prompt is required');
   });
 
@@ -47,13 +47,13 @@ describe('speech design command', () => {
       await designCommand.execute(baseConfig, {
         ...baseFlags,
         prompt: 'Warm and clear narrator',
-        voiceId: 'designed_voice',
+        previewText: 'Welcome to the show',
       });
 
       const parsed = JSON.parse(output);
       expect(parsed.request).toEqual({
         prompt: 'Warm and clear narrator',
-        voice_id: 'designed_voice',
+        preview_text: 'Welcome to the show',
       });
     } finally {
       console.log = originalLog;

--- a/test/commands/speech/design.test.ts
+++ b/test/commands/speech/design.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'bun:test';
+import { default as designCommand } from '../../../src/commands/speech/design';
+
+const baseConfig = {
+  apiKey: 'test-key',
+  region: 'global' as const,
+  baseUrl: 'https://api.mmx.io',
+  output: 'json' as const,
+  timeout: 10,
+  verbose: false,
+  quiet: false,
+  noColor: true,
+  yes: false,
+  dryRun: true,
+  nonInteractive: true,
+  async: false,
+};
+
+const baseFlags = {
+  quiet: false,
+  verbose: false,
+  noColor: true,
+  yes: false,
+  dryRun: true,
+  help: false,
+  nonInteractive: true,
+  async: false,
+};
+
+describe('speech design command', () => {
+  it('has correct name', () => {
+    expect(designCommand.name).toBe('speech design');
+  });
+
+  it('requires prompt', async () => {
+    await expect(
+      designCommand.execute(baseConfig, { ...baseFlags, voiceId: 'designed_voice' }),
+    ).rejects.toThrow('--prompt is required');
+  });
+
+  it('builds design request', async () => {
+    const originalLog = console.log;
+    let output = '';
+    console.log = (msg: string) => { output += msg; };
+
+    try {
+      await designCommand.execute(baseConfig, {
+        ...baseFlags,
+        prompt: 'Warm and clear narrator',
+        voiceId: 'designed_voice',
+      });
+
+      const parsed = JSON.parse(output);
+      expect(parsed.request).toEqual({
+        prompt: 'Warm and clear narrator',
+        voice_id: 'designed_voice',
+      });
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/test/sdk/speech.test.ts
+++ b/test/sdk/speech.test.ts
@@ -75,12 +75,14 @@ describe('MiniMaxSDK.speech', () => {
         '/v1/voice_clone': async (req) => {
           const body = await req.json() as Record<string, unknown>;
           expect(body).toEqual({
-            file_id: 'file-123',
+            file_id: 123,
             voice_id: 'my_voice',
-            model: 'speech-2.8-hd',
           });
           return jsonResponse({
-            voice_id: 'my_voice',
+            input_sensitive: false,
+            input_sensitive_type: 0,
+            demo_audio: '',
+            extra_info: { audio_length: 1000 },
             base_resp: { status_code: 0, status_msg: 'success' },
           });
         },
@@ -93,12 +95,11 @@ describe('MiniMaxSDK.speech', () => {
     });
 
     const result = await sdk.speech.clone({
-      file_id: 'file-123',
+      file_id: 123,
       voice_id: 'my_voice',
-      model: 'speech-2.8-hd',
     });
 
-    expect(result.voice_id).toBe('my_voice');
+    expect(result.input_sensitive).toBe(false);
   });
 
   it('should design a voice successfully', async () => {
@@ -108,10 +109,10 @@ describe('MiniMaxSDK.speech', () => {
           const body = await req.json() as Record<string, unknown>;
           expect(body).toEqual({
             prompt: 'Warm and clear narrator',
-            voice_id: 'designed_voice',
+            preview_text: 'Welcome to the show',
           });
           return jsonResponse({
-            voice_id: 'designed_voice',
+            trial_audio: 'hex-audio',
             base_resp: { status_code: 0, status_msg: 'success' },
           });
         },
@@ -125,10 +126,10 @@ describe('MiniMaxSDK.speech', () => {
 
     const result = await sdk.speech.design({
       prompt: 'Warm and clear narrator',
-      voice_id: 'designed_voice',
+      preview_text: 'Welcome to the show',
     });
 
-    expect(result.voice_id).toBe('designed_voice');
+    expect(result.trial_audio).toBe('hex-audio');
   });
 });
 

--- a/test/sdk/speech.test.ts
+++ b/test/sdk/speech.test.ts
@@ -68,6 +68,68 @@ describe('MiniMaxSDK.speech', () => {
     expect(voices).toHaveLength(1);
     expect(voices[0].voice_id).toBe('voice-1');
   });
+
+  it('should clone a voice successfully', async () => {
+    server = createMockServer({
+      routes: {
+        '/v1/voice_clone': async (req) => {
+          const body = await req.json() as Record<string, unknown>;
+          expect(body).toEqual({
+            file_id: 'file-123',
+            voice_id: 'my_voice',
+            model: 'speech-2.8-hd',
+          });
+          return jsonResponse({
+            voice_id: 'my_voice',
+            base_resp: { status_code: 0, status_msg: 'success' },
+          });
+        },
+      },
+    });
+
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+
+    const result = await sdk.speech.clone({
+      file_id: 'file-123',
+      voice_id: 'my_voice',
+      model: 'speech-2.8-hd',
+    });
+
+    expect(result.voice_id).toBe('my_voice');
+  });
+
+  it('should design a voice successfully', async () => {
+    server = createMockServer({
+      routes: {
+        '/v1/voice_design': async (req) => {
+          const body = await req.json() as Record<string, unknown>;
+          expect(body).toEqual({
+            prompt: 'Warm and clear narrator',
+            voice_id: 'designed_voice',
+          });
+          return jsonResponse({
+            voice_id: 'designed_voice',
+            base_resp: { status_code: 0, status_msg: 'success' },
+          });
+        },
+      },
+    });
+
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+
+    const result = await sdk.speech.design({
+      prompt: 'Warm and clear narrator',
+      voice_id: 'designed_voice',
+    });
+
+    expect(result.voice_id).toBe('designed_voice');
+  });
 });
 
 describe('SpeechSDK.save', () => {


### PR DESCRIPTION
Reason: Add voice cloning and voice design support to the speech CLI and SDK.

Changes:
- Add voice clone and voice design endpoint helpers and response/request types.
- Add mmx speech clone and mmx speech design commands.
- Add speech SDK helpers for clone/design and clone/prompt audio upload purposes.
- Cover the new command registry entries, dry-run payloads, and SDK request parsing with tests.

Checks:
- bun test test/commands/speech/clone.test.ts test/commands/speech/design.test.ts test/sdk/speech.test.ts test/commands/aliases.test.ts
- bun run typecheck
- bun run lint
- bun test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788228746&installation_model_id=427615&pr_number=221&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F221&signature=7d631052400ccef2392d206a0143817e6454ca8e4ae0307a4825ecdfcd343d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->