### PR TITLE
fix: enforce H3 reference input limit

### DIFF
--- a/src/video/v2.ts
+++ b/src/video/v2.ts
@@ -31,6 +31,8 @@ const VIDEO_V2_IMAGE_ROLES = new Set<VideoV2ImageRole>([
   'reference_image',
 ]);
 
+const VIDEO_V2_MAX_REFERENCE_INPUTS = 12;
+
 export class VideoV2InputError extends Error {
   constructor(message: string) {
     super(message);
@@ -186,6 +188,11 @@ export function validateVideoV2Request(request: VideoV2Request): void {
   }
   if (referenceImages.length > 9 || videos.length > 3 || audios.length > 3) {
     throw new VideoV2InputError('MiniMax-H3 accepts up to 9 reference images, 3 reference videos, and 3 reference audios.');
+  }
+  if (referenceImages.length + videos.length + audios.length > VIDEO_V2_MAX_REFERENCE_INPUTS) {
+    throw new VideoV2InputError(
+      `MiniMax-H3 accepts up to ${VIDEO_V2_MAX_REFERENCE_INPUTS} reference images, videos, and audios in total.`,
+    );
   }
   if (hasFrameInput && hasReferenceInput) {
     throw new VideoV2InputError('MiniMax-H3 frame inputs and reference inputs cannot be used together.');

--- a/test/video/v2.test.ts
+++ b/test/video/v2.test.ts
@@ -152,6 +152,21 @@ describe('Video Generation V2 request builder', () => {
     })).toThrow('3 reference audios');
   });
 
+  it('enforces the combined reference input limit', () => {
+    expect(() => buildVideoV2Request({
+      prompt,
+      images: referenceImages(9),
+      referenceVideos: referenceMedia(3, 'mp4'),
+    })).not.toThrow();
+
+    expect(() => buildVideoV2Request({
+      prompt,
+      images: referenceImages(9),
+      referenceVideos: referenceMedia(3, 'mp4'),
+      referenceAudios: referenceMedia(1, 'mp3'),
+    })).toThrow('up to 12 reference images, videos, and audios in total');
+  });
+
   it('rejects oversized Base64 image, video, and audio inputs', () => {
     expect(() => buildVideoV2Request({
       prompt,


### PR DESCRIPTION
## Summary

- enforce MiniMax-H3's combined limit of 12 reference images, videos, and audios
- keep the existing per-media limits of 9 images, 3 videos, and 3 audios
- add regression coverage proving 12 mixed references are accepted and 13 are rejected

## Root cause

The H3 validator checked each media type independently but did not check their combined count. A request containing 9 reference images, 3 reference videos, and 3 reference audios therefore passed local validation with 15 total references, even though mixed-reference requests allow at most 12.

## Impact

Oversized mixed-reference requests now fail locally with an actionable usage error before a paid generation request is submitted.

## Validation

- `bun test test/video/v2.test.ts` — 12 passed
- `bun test` — 450 passed
- `bun run typecheck`
- `bun run lint` — 0 errors; 1 pre-existing warning in `test/sdk/speech.test.ts`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788361891&installation_model_id=427615&pr_number=222&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F222&signature=9d6ee4d4db9dd4eeb1e2937f11699b53d3d803c8927ac608b3e3b11416fad119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->