### PR TITLE
feat(text chat): expose image input via repeatable --image (multimodal M3, multi-image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ mmx text chat --model MiniMax-M3 --message "Hello" --stream
 mmx text chat --system "You are a coding assistant" --message "Fizzbuzz in Go"
 mmx text chat --message "user:Hi" --message "assistant:Hey!" --message "How are you?"
 cat messages.json | mmx text chat --messages-file - --output json
+mmx text chat --image photo.jpg --message "What breed is this dog?"
+mmx text chat --image before.png --image after.png --message "What changed?"
 ```
 
 ### `mmx image`

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,6 +70,8 @@ mmx text chat --model MiniMax-M3 --message "你好" --stream
 mmx text chat --system "你是编程助手" --message "用 Go 写 Fizzbuzz"
 mmx text chat --message "user:你好" --message "assistant:嗨！" --message "你叫什么名字？"
 cat messages.json | mmx text chat --messages-file - --output json
+mmx text chat --image photo.jpg --message "这是什么品种的狗？"
+mmx text chat --image before.png --image after.png --message "这两张图有什么不同？"
 ```
 
 ### `mmx image`

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -54,7 +54,7 @@ mmx text chat --message <text> [flags]
 
 | Flag | Type | Description |
 |---|---|---|
-| `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
+| `--message <text>` | string, repeatable (required unless `--image` or `--messages-file` is given) | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
 | `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
 | `--system <text>` | string | System prompt |
 | `--image <path-or-url>` | string, repeatable | Image to send with the message (auto base64-encoded). Forces `MiniMax-M3` unless `--model` is set |
@@ -86,7 +86,8 @@ mmx text chat --image before.png --image after.png \
 
 `text chat` posts to the Anthropic-compatible `/messages` endpoint, so hand-written
 `--messages-file` image blocks must use `{"type":"image","source":{"type":"base64",...}}`.
-The OpenAI `image_url` shape is rejected. `--image` emits the correct shape for you.
+The OpenAI `image_url` shape is rejected. `--image` emits the base64 shape for you; a hand-written
+`--messages-file` may also use `{"type":"image","source":{"type":"url","url":"https://..."}}`.
 
 **stdout**: response text (text mode) or full response object (json mode).
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -57,6 +57,7 @@ mmx text chat --message <text> [flags]
 | `--message <text>` | string, **required**, repeatable | Message text. Prefix with `role:` to set role (e.g. `"system:You are helpful"`, `"user:Hello"`) |
 | `--messages-file <path>` | string | JSON file with messages array. Use `-` for stdin |
 | `--system <text>` | string | System prompt |
+| `--image <path-or-url>` | string, repeatable | Image to send with the message (auto base64-encoded). Forces `MiniMax-M3` unless `--model` is set |
 | `--model <model>` | string | Model ID (default: `MiniMax-M3`) |
 | `--max-tokens <n>` | number | Max tokens (default: 4096) |
 | `--temperature <n>` | number | Sampling temperature (0.0, 1.0] |
@@ -76,7 +77,16 @@ mmx text chat \
 
 # From file
 cat conversation.json | mmx text chat --messages-file - --output json
+
+# With images (M3 is multimodal; --image is repeatable)
+mmx text chat --image photo.jpg --message "What breed is this dog?" --quiet
+mmx text chat --image before.png --image after.png \
+  --message "List every visual difference between these two." --quiet
 ```
+
+`text chat` posts to the Anthropic-compatible `/messages` endpoint, so hand-written
+`--messages-file` image blocks must use `{"type":"image","source":{"type":"base64",...}}`.
+The OpenAI `image_url` shape is rejected. `--image` emits the correct shape for you.
 
 **stdout**: response text (text mode) or full response object (json mode).
 

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -20,6 +20,12 @@ import { readTextFromPathOrStdin } from '../../utils/fs';
 import { promptText, failIfMissing } from '../../utils/prompt';
 import { toImageBlock } from '../../utils/image';
 
+// MiniMax Anthropic API contract (platform.minimax.io/docs/api-reference/text-anthropic-api):
+// per-image cap, supported formats, and the whole-request-body cap.
+const CHAT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+const CHAT_IMAGE_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const CHAT_MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Thinking indicator — dynamic spinner + color-cycling label
 // ---------------------------------------------------------------------------
@@ -221,7 +227,30 @@ export default defineCommand({
     }
 
     if (imageInputs.length > 0) {
-      attachImages(messages, await Promise.all(imageInputs.map(toImageBlock)));
+      const images: ContentBlock[] = [];
+      // Track the running request-body size so a run bails as soon as it's
+      // clear the request would exceed the cap, not after every image is
+      // fetched and encoded.
+      let requestBytes = Buffer.byteLength(JSON.stringify(messages), 'utf-8')
+        + Buffer.byteLength(system ?? '', 'utf-8');
+
+      for (const input of imageInputs) {
+        const block = await toImageBlock(input, {
+          maxBytes: CHAT_IMAGE_MAX_BYTES,
+          allowedMediaTypes: CHAT_IMAGE_ALLOWED_TYPES,
+        });
+        requestBytes += block.source.data.length;
+        if (requestBytes > CHAT_MAX_REQUEST_BYTES) {
+          throw new CLIError(
+            `Request body exceeds the ${CHAT_MAX_REQUEST_BYTES / 1024 / 1024} MB limit once this image is attached.`,
+            ExitCode.USAGE,
+            'Send fewer or smaller --image inputs.',
+          );
+        }
+        images.push(block);
+      }
+
+      attachImages(messages, images);
     }
 
     // Images require a multimodal model, so they override a text-only config default.

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -18,6 +18,7 @@ import { readFileSync } from 'fs';
 import { isInteractive } from '../../utils/env';
 import { readTextFromPathOrStdin } from '../../utils/fs';
 import { promptText, failIfMissing } from '../../utils/prompt';
+import { toImageBlock } from '../../utils/image';
 
 // ---------------------------------------------------------------------------
 // Thinking indicator — dynamic spinner + color-cycling label
@@ -145,6 +146,27 @@ function parseMessages(flags: GlobalFlags): ParsedMessages {
   return { system, messages };
 }
 
+/**
+ * Attach image blocks to the last user message, promoting its content from a
+ * bare string to a block array. Images land after the text so the model reads
+ * the instruction first.
+ */
+function attachImages(messages: ChatMessage[], images: ContentBlock[]): void {
+  let idx = messages.length - 1;
+  while (idx >= 0 && messages[idx]!.role !== 'user') idx--;
+
+  if (idx < 0) {
+    messages.push({ role: 'user', content: images });
+    return;
+  }
+
+  const target = messages[idx]!;
+  const content = typeof target.content === 'string'
+    ? (target.content ? [{ type: 'text' as const, text: target.content }] : [])
+    : target.content;
+  target.content = [...content, ...images];
+}
+
 function extractText(content: ContentBlock[]): string {
   return content
     .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
@@ -162,6 +184,7 @@ export default defineCommand({
     { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role)', required: true, type: 'array' },
     { flag: '--messages-file <path>',  description: 'JSON file with messages array (use - for stdin)' },
     { flag: '--system <text>',         description: 'System prompt' },
+    { flag: '--image <path-or-url>',   description: 'Image to send with the message (repeatable, base64 encoded automatically)', type: 'array' },
     { flag: '--max-tokens <n>',        description: 'Maximum tokens to generate (default: 4096)', type: 'number' },
     { flag: '--temperature <n>',       description: 'Sampling temperature (0.0, 1.0]', type: 'number' },
     { flag: '--top-p <n>',             description: 'Nucleus sampling threshold', type: 'number' },
@@ -172,14 +195,17 @@ export default defineCommand({
     'mmx text chat --message "What is MiniMax?"',
     'mmx text chat --model MiniMax-M3 --system "You are a coding assistant." --message "Write fizzbuzz in Python"',
     'mmx text chat --message "Hello" --message "assistant:Hi!" --message "How are you?"',
+    'mmx text chat --image photo.jpg --message "What breed is this dog?"',
+    'mmx text chat --image before.png --image after.png --message "List every visual difference."',
     'cat conversation.json | mmx text chat --messages-file - --stream',
     'mmx text chat --message "Hello" --output json',
   ],
   async run(config: Config, flags: GlobalFlags) {
     const { system, messages: parsedMessages } = parseMessages(flags);
     let messages = parsedMessages;
+    const imageInputs = (flags.image as string[] | undefined) ?? [];
 
-    if (messages.length === 0) {
+    if (messages.length === 0 && imageInputs.length === 0) {
       if (isInteractive({ nonInteractive: config.nonInteractive })) {
         const hint = await promptText({
           message: 'Enter your message:',
@@ -194,8 +220,13 @@ export default defineCommand({
       }
     }
 
+    if (imageInputs.length > 0) {
+      attachImages(messages, await Promise.all(imageInputs.map(toImageBlock)));
+    }
+
+    // Images require a multimodal model, so they override a text-only config default.
     const model = (flags.model as string)
-      || config.defaultTextModel
+      || (imageInputs.length > 0 ? 'MiniMax-M3' : config.defaultTextModel)
       || 'MiniMax-M3';
     const format = detectOutputFormat(config.output);
     const shouldStream = flags.stream === true || (

--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -153,20 +153,20 @@ function parseMessages(flags: GlobalFlags): ParsedMessages {
 }
 
 /**
- * Attach image blocks to the last user message, promoting its content from a
+ * Attach image blocks to the final user message, promoting its content from a
  * bare string to a block array. Images land after the text so the model reads
- * the instruction first.
+ * the instruction first. If the conversation does not end with a user message
+ * (empty, or the assistant spoke last), the images become a new user turn rather
+ * than being spliced into an earlier one.
  */
 function attachImages(messages: ChatMessage[], images: ContentBlock[]): void {
-  let idx = messages.length - 1;
-  while (idx >= 0 && messages[idx]!.role !== 'user') idx--;
-
-  if (idx < 0) {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'user') {
     messages.push({ role: 'user', content: images });
     return;
   }
 
-  const target = messages[idx]!;
+  const target = last;
   const content = typeof target.content === 'string'
     ? (target.content ? [{ type: 'text' as const, text: target.content }] : [])
     : target.content;
@@ -187,7 +187,7 @@ export default defineCommand({
   usage: 'mmx text chat --message <text> [flags]',
   options: [
     { flag: '--model <model>', description: 'Model ID (default: MiniMax-M3)' },
-    { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role)', required: true, type: 'array' },
+    { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role; optional when --image or --messages-file is given)', type: 'array' },
     { flag: '--messages-file <path>',  description: 'JSON file with messages array (use - for stdin)' },
     { flag: '--system <text>',         description: 'System prompt' },
     { flag: '--image <path-or-url>',   description: 'Image to send with the message (repeatable, base64 encoded automatically)', type: 'array' },
@@ -293,6 +293,17 @@ export default defineCommand({
         }
       });
       body.tools = tools;
+    }
+
+    // The per-image accumulation above is a fast fail on a lower bound; this is the
+    // authoritative check on the bytes that actually go on the wire.
+    const wireBytes = Buffer.byteLength(JSON.stringify(body), 'utf-8');
+    if (wireBytes > CHAT_MAX_REQUEST_BYTES) {
+      throw new CLIError(
+        `Request body is ${(wireBytes / 1024 / 1024).toFixed(1)} MB; the API limit is ${CHAT_MAX_REQUEST_BYTES / 1024 / 1024} MB.`,
+        ExitCode.USAGE,
+        'Send fewer or smaller --image inputs, or shorten the message and system text.',
+      );
     }
 
     if (config.dryRun) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,7 +4,8 @@ export type ContentBlock =
   | { type: 'text'; text: string }
   | { type: 'thinking'; thinking: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
-  | { type: 'tool_result'; tool_use_id: string; content: string };
+  | { type: 'tool_result'; tool_use_id: string; content: string }
+  | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } };
 
 export interface ChatMessage {
   role: 'user' | 'assistant';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5,7 +5,12 @@ export type ContentBlock =
   | { type: 'thinking'; thinking: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string }
-  | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } };
+  | { type: 'image'; source: ImageSource };
+
+/** Image source shapes accepted by the Messages API. `--image` always emits base64. */
+export type ImageSource =
+  | { type: 'base64'; media_type: string; data: string }
+  | { type: 'url'; url: string };
 
 export interface ChatMessage {
   role: 'user' | 'assistant';

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -2,10 +2,9 @@ import { readFileSync, existsSync, statSync } from 'fs';
 import { extname } from 'path';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
-import type { ContentBlock } from '../types/api';
 import { dataUriDecodedSize } from './media';
 
-type ImageBlock = Extract<ContentBlock, { type: 'image' }>;
+type ImageBlock = { type: 'image'; source: { type: 'base64'; media_type: string; data: string } };
 
 export const IMAGE_MIME_TYPES: Record<string, string> = {
   '.jpg': 'image/jpeg',
@@ -46,6 +45,35 @@ export function resolveImageInput(input: string, maxBytes?: number): string {
 }
 
 const MAX_IMAGE_SIZE_BYTES = 50 * 1024 * 1024;
+
+async function readBodyWithLimit(res: Response, maxBytes: number): Promise<Buffer> {
+  if (!res.body) {
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.byteLength > maxBytes) throw tooLarge(buf.byteLength, maxBytes);
+    return buf;
+  }
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > maxBytes) {
+      await reader.cancel();
+      throw tooLarge(received, maxBytes);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+function tooLarge(bytes: number, maxBytes: number): CLIError {
+  return new CLIError(
+    `Image too large (${(bytes / 1024 / 1024).toFixed(1)} MB received). Maximum is ${(maxBytes / 1024 / 1024).toFixed(0)} MB.`,
+    ExitCode.USAGE,
+  );
+}
 
 export async function toDataUri(image: string, opts?: ImageValidationOptions): Promise<string> {
   if (image.startsWith('data:')) {
@@ -93,14 +121,10 @@ export async function toDataUri(image: string, opts?: ImageValidationOptions): P
       }
     }
 
-    const buf = await res.arrayBuffer();
-    if (buf.byteLength > maxBytes) {
-      throw new CLIError(
-        `Image too large (${(buf.byteLength / 1024 / 1024).toFixed(1)} MB). Maximum is ${(maxBytes / 1024 / 1024).toFixed(0)} MB.`,
-        ExitCode.USAGE,
-      );
-    }
-    return `data:${mime};base64,${Buffer.from(buf).toString('base64')}`;
+    // content-length is advisory; enforce the cap on the bytes actually received and
+    // cancel the download the moment it is exceeded instead of buffering the whole body.
+    const buf = await readBodyWithLimit(res, maxBytes);
+    return `data:${mime};base64,${buf.toString('base64')}`;
   }
 
   if (!existsSync(image)) throw new CLIError(`File not found: ${image}`, ExitCode.USAGE);

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -3,6 +3,7 @@ import { extname } from 'path';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
 import type { ContentBlock } from '../types/api';
+import { dataUriDecodedSize } from './media';
 
 type ImageBlock = Extract<ContentBlock, { type: 'image' }>;
 
@@ -15,7 +16,13 @@ export const IMAGE_MIME_TYPES: Record<string, string> = {
   '.heif': 'image/heif',
 };
 
-export function localFileToDataUri(filePath: string, maxBytes?: number): string {
+/** Per-image and format constraints for a specific caller (e.g. chat's Anthropic-API contract). */
+export interface ImageValidationOptions {
+  maxBytes: number;
+  allowedMediaTypes: readonly string[];
+}
+
+export function localFileToDataUri(filePath: string, maxBytes?: number, mimeOverride?: string): string {
   if (maxBytes !== undefined) {
     const size = statSync(filePath).size;
     if (size > maxBytes) {
@@ -27,7 +34,7 @@ export function localFileToDataUri(filePath: string, maxBytes?: number): string 
     }
   }
   const ext = extname(filePath).toLowerCase();
-  const mime = IMAGE_MIME_TYPES[ext] || 'image/jpeg';
+  const mime = mimeOverride || IMAGE_MIME_TYPES[ext] || 'image/jpeg';
   const data = readFileSync(filePath);
   return `data:${mime};base64,${data.toString('base64')}`;
 }
@@ -40,18 +47,56 @@ export function resolveImageInput(input: string, maxBytes?: number): string {
 
 const MAX_IMAGE_SIZE_BYTES = 50 * 1024 * 1024;
 
-export async function toDataUri(image: string): Promise<string> {
-  if (image.startsWith('data:')) return image;
+export async function toDataUri(image: string, opts?: ImageValidationOptions): Promise<string> {
+  if (image.startsWith('data:')) {
+    if (opts) {
+      const mime = /^data:([^;,]+)[;,]/.exec(image)?.[1];
+      if (!mime || !opts.allowedMediaTypes.includes(mime)) {
+        throw new CLIError(
+          `Unsupported image type "${mime ?? 'unknown'}". Supported: ${opts.allowedMediaTypes.join(', ')}`,
+          ExitCode.USAGE,
+        );
+      }
+      const size = dataUriDecodedSize(image);
+      if (size !== undefined && size > opts.maxBytes) {
+        throw new CLIError(
+          `Image too large (${(size / 1024 / 1024).toFixed(1)} MB). Maximum is ${(opts.maxBytes / 1024 / 1024).toFixed(0)} MB.`,
+          ExitCode.USAGE,
+        );
+      }
+    }
+    return image;
+  }
 
   if (image.startsWith('http://') || image.startsWith('https://')) {
     const res = await fetch(image);
     if (!res.ok) throw new CLIError(`Failed to download image: HTTP ${res.status}`, ExitCode.GENERAL);
     const contentType = res.headers.get('content-type') || 'image/jpeg';
     const mime = contentType.split(';')[0]!.trim();
+    const maxBytes = opts?.maxBytes ?? MAX_IMAGE_SIZE_BYTES;
+
+    if (opts) {
+      if (!opts.allowedMediaTypes.includes(mime)) {
+        throw new CLIError(
+          `Unsupported image type "${mime}". Supported: ${opts.allowedMediaTypes.join(', ')}`,
+          ExitCode.USAGE,
+        );
+      }
+      // content-length can lie or be absent, but checking it first avoids
+      // buffering an oversized body just to reject it a moment later.
+      const contentLength = Number(res.headers.get('content-length'));
+      if (contentLength > maxBytes) {
+        throw new CLIError(
+          `Image too large (${(contentLength / 1024 / 1024).toFixed(1)} MB). Maximum is ${(maxBytes / 1024 / 1024).toFixed(0)} MB.`,
+          ExitCode.USAGE,
+        );
+      }
+    }
+
     const buf = await res.arrayBuffer();
-    if (buf.byteLength > MAX_IMAGE_SIZE_BYTES) {
+    if (buf.byteLength > maxBytes) {
       throw new CLIError(
-        `Image too large (${(buf.byteLength / 1024 / 1024).toFixed(1)} MB). Maximum is 50 MB.`,
+        `Image too large (${(buf.byteLength / 1024 / 1024).toFixed(1)} MB). Maximum is ${(maxBytes / 1024 / 1024).toFixed(0)} MB.`,
         ExitCode.USAGE,
       );
     }
@@ -60,7 +105,25 @@ export async function toDataUri(image: string): Promise<string> {
 
   if (!existsSync(image)) throw new CLIError(`File not found: ${image}`, ExitCode.USAGE);
   const ext = extname(image).toLowerCase();
-  if (!IMAGE_MIME_TYPES[ext]) throw new CLIError(`Unsupported image format "${ext}". Supported: jpg, jpeg, png, webp`, ExitCode.USAGE);
+  const mime = opts
+    ? (IMAGE_MIME_TYPES[ext] ?? (ext === '.gif' ? 'image/gif' : undefined))
+    : IMAGE_MIME_TYPES[ext];
+  if (!mime || (opts && !opts.allowedMediaTypes.includes(mime))) {
+    throw new CLIError(
+      `Unsupported image format "${ext}". Supported: ${opts ? opts.allowedMediaTypes.join(', ') : 'jpg, jpeg, png, webp'}`,
+      ExitCode.USAGE,
+    );
+  }
+  if (opts) {
+    const size = statSync(image).size;
+    if (size > opts.maxBytes) {
+      throw new CLIError(
+        `Image too large (${(size / 1024 / 1024).toFixed(1)} MB). Maximum is ${(opts.maxBytes / 1024 / 1024).toFixed(0)} MB.`,
+        ExitCode.USAGE,
+      );
+    }
+    return localFileToDataUri(image, undefined, mime);
+  }
   return localFileToDataUri(image);
 }
 
@@ -69,8 +132,8 @@ export async function toDataUri(image: string): Promise<string> {
  * The Messages API rejects the OpenAI `image_url` shape, so callers targeting
  * `/anthropic/v1/messages` must use this instead of a raw data URI.
  */
-export async function toImageBlock(image: string): Promise<ImageBlock> {
-  const uri = await toDataUri(image);
+export async function toImageBlock(image: string, opts?: ImageValidationOptions): Promise<ImageBlock> {
+  const uri = await toDataUri(image, opts);
   const match = /^data:([^;,]+);base64,(.*)$/s.exec(uri);
   if (!match) {
     throw new CLIError(

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -2,6 +2,9 @@ import { readFileSync, existsSync, statSync } from 'fs';
 import { extname } from 'path';
 import { CLIError } from '../errors/base';
 import { ExitCode } from '../errors/codes';
+import type { ContentBlock } from '../types/api';
+
+type ImageBlock = Extract<ContentBlock, { type: 'image' }>;
 
 export const IMAGE_MIME_TYPES: Record<string, string> = {
   '.jpg': 'image/jpeg',
@@ -59,4 +62,21 @@ export async function toDataUri(image: string): Promise<string> {
   const ext = extname(image).toLowerCase();
   if (!IMAGE_MIME_TYPES[ext]) throw new CLIError(`Unsupported image format "${ext}". Supported: jpg, jpeg, png, webp`, ExitCode.USAGE);
   return localFileToDataUri(image);
+}
+
+/**
+ * Convert a path / URL / data URI into an Anthropic-shaped image content block.
+ * The Messages API rejects the OpenAI `image_url` shape, so callers targeting
+ * `/anthropic/v1/messages` must use this instead of a raw data URI.
+ */
+export async function toImageBlock(image: string): Promise<ImageBlock> {
+  const uri = await toDataUri(image);
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(uri);
+  if (!match) {
+    throw new CLIError(
+      `Unsupported image source "${image}": expected a base64 data URI, file path, or http(s) URL.`,
+      ExitCode.USAGE,
+    );
+  }
+  return { type: 'image', source: { type: 'base64', media_type: match[1]!, data: match[2]! } };
 }

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { createMockServer, jsonResponse, sseResponse, type MockServer } from '../../helpers/mock-server';
 import textChatResponse from '../../fixtures/text-chat-response.json';
 import type { Config } from '../../../src/config/schema';
@@ -301,5 +304,112 @@ describe('text chat command', () => {
     } finally {
       console.log = originalLog;
     }
+  });
+
+  describe('--image', () => {
+    // 1x1 transparent PNG
+    const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    const dir = mkdtempSync(join(tmpdir(), 'mmx-chat-image-'));
+    const imgA = join(dir, 'a.png');
+    const imgB = join(dir, 'b.png');
+    writeFileSync(imgA, Buffer.from(PNG_BASE64, 'base64'));
+    writeFileSync(imgB, Buffer.from(PNG_BASE64, 'base64'));
+
+    const baseConfig: Config = {
+      apiKey: 'test-key',
+      region: 'global' as const,
+      baseUrl: 'https://api.mmx.io',
+      output: 'json',
+      timeout: 10,
+      verbose: false,
+      quiet: false,
+      noColor: true,
+      yes: false,
+      dryRun: true,
+      nonInteractive: true,
+      async: false,
+    };
+
+    const baseFlags = {
+      quiet: false,
+      verbose: false,
+      noColor: true,
+      yes: false,
+      dryRun: true,
+      help: false,
+      nonInteractive: true,
+      async: false,
+    };
+
+    async function dryRunRequest(config: Config, flags: Record<string, unknown>) {
+      const { default: chatCommand } = await import('../../../src/commands/text/chat');
+      const originalLog = console.log;
+      let output = '';
+      console.log = (msg: string) => { output += msg; };
+      try {
+        await chatCommand.execute(config, { ...baseFlags, ...flags } as never);
+      } finally {
+        console.log = originalLog;
+      }
+      return JSON.parse(output).request;
+    }
+
+    it('appends Anthropic-shaped image blocks to the user message', async () => {
+      const request = await dryRunRequest(baseConfig, {
+        message: ['What is this?'],
+        image: [imgA],
+      });
+
+      expect(request.messages).toHaveLength(1);
+      expect(request.messages[0].content).toEqual([
+        { type: 'text', text: 'What is this?' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_BASE64 } },
+      ]);
+    });
+
+    it('supports multiple images in one message', async () => {
+      const request = await dryRunRequest(baseConfig, {
+        message: ['Compare these.'],
+        image: [imgA, imgB],
+      });
+
+      const blocks = request.messages[0].content;
+      expect(blocks).toHaveLength(3);
+      expect(blocks.filter((b: { type: string }) => b.type === 'image')).toHaveLength(2);
+    });
+
+    it('sends images with no --message', async () => {
+      const request = await dryRunRequest(baseConfig, { image: [imgA] });
+
+      expect(request.messages).toHaveLength(1);
+      expect(request.messages[0].role).toBe('user');
+      expect(request.messages[0].content).toEqual([
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_BASE64 } },
+      ]);
+    });
+
+    it('overrides a text-only defaultTextModel with MiniMax-M3', async () => {
+      const request = await dryRunRequest(
+        { ...baseConfig, defaultTextModel: 'MiniMax-Text-01' },
+        { message: ['What is this?'], image: [imgA] },
+      );
+
+      expect(request.model).toBe('MiniMax-M3');
+    });
+
+    it('still honours an explicit --model', async () => {
+      const request = await dryRunRequest(
+        { ...baseConfig, defaultTextModel: 'MiniMax-Text-01' },
+        { message: ['What is this?'], image: [imgA], model: 'MiniMax-VL-01' },
+      );
+
+      expect(request.model).toBe('MiniMax-VL-01');
+    });
+
+    it('errors on a missing image file', async () => {
+      await expect(
+        dryRunRequest(baseConfig, { message: ['hi'], image: [join(dir, 'nope.png')] }),
+      ).rejects.toThrow(/File not found/);
+    });
   });
 });

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync } from 'fs';
+import { mkdtempSync, writeFileSync, truncateSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { createMockServer, jsonResponse, sseResponse, type MockServer } from '../../helpers/mock-server';
@@ -410,6 +410,71 @@ describe('text chat command', () => {
       await expect(
         dryRunRequest(baseConfig, { message: ['hi'], image: [join(dir, 'nope.png')] }),
       ).rejects.toThrow(/File not found/);
+    });
+
+    it('rejects an oversized local image', async () => {
+      const big = join(dir, 'big.png');
+      writeFileSync(big, '');
+      truncateSync(big, 11 * 1024 * 1024);
+
+      await expect(
+        dryRunRequest(baseConfig, { message: ['hi'], image: [big] }),
+      ).rejects.toThrow(/too large/i);
+    });
+
+    it('rejects HEIC images for chat', async () => {
+      const heic = join(dir, 'photo.heic');
+      writeFileSync(heic, Buffer.from('not really heic'));
+
+      await expect(
+        dryRunRequest(baseConfig, { message: ['hi'], image: [heic] }),
+      ).rejects.toThrow(/Unsupported image format/);
+    });
+
+    it('accepts GIF images for chat', async () => {
+      const gif = join(dir, 'a.gif');
+      writeFileSync(gif, Buffer.from('GIF89a'));
+
+      const request = await dryRunRequest(baseConfig, { message: ['hi'], image: [gif] });
+      const block = request.messages[0].content.find((b: { type: string }) => b.type === 'image');
+      expect(block.source.media_type).toBe('image/gif');
+    });
+
+    it('rejects a remote image over 10 MB via content-length', async () => {
+      const imgServer = createMockServer({
+        routes: {
+          '/big.png': () => new Response(Buffer.alloc(11 * 1024 * 1024), {
+            headers: { 'Content-Type': 'image/png' },
+          }),
+        },
+      });
+
+      try {
+        await expect(
+          dryRunRequest(baseConfig, { message: ['hi'], image: [`${imgServer.url}/big.png`] }),
+        ).rejects.toThrow(/too large/i);
+      } finally {
+        imgServer.close();
+      }
+    });
+
+    it('rejects a data: URI image over the per-image cap', async () => {
+      const oversized = 'A'.repeat(Math.ceil((11 * 1024 * 1024) / 3) * 4);
+
+      await expect(
+        dryRunRequest(baseConfig, { message: ['hi'], image: [`data:image/png;base64,${oversized}`] }),
+      ).rejects.toThrow(/too large/i);
+    });
+
+    it('rejects when images cumulatively exceed the 64 MB request cap', async () => {
+      // ~7.15 MB decoded each — under the 10 MB per-image cap, but seven of
+      // them push the whole request past the 64 MB aggregate cap.
+      const chunk = 'A'.repeat(10_000_000);
+      const images = Array.from({ length: 7 }, () => `data:image/png;base64,${chunk}`);
+
+      await expect(
+        dryRunRequest(baseConfig, { message: ['hi'], image: images }),
+      ).rejects.toThrow(/64 MB/);
     });
   });
 });

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -466,6 +466,59 @@ describe('text chat command', () => {
       ).rejects.toThrow(/too large/i);
     });
 
+    it('starts a new user turn when the assistant spoke last', async () => {
+      const request = await dryRunRequest(baseConfig, {
+        message: ['Describe the first one.', 'assistant:Sure — send it over.'],
+        image: [imgA],
+      });
+
+      expect(request.messages).toHaveLength(3);
+      expect(request.messages[0].role).toBe('user');
+      expect(request.messages[0].content).toBe('Describe the first one.');
+      expect(request.messages[1].role).toBe('assistant');
+      expect(request.messages[2].role).toBe('user');
+      expect(request.messages[2].content).toHaveLength(1);
+      expect(request.messages[2].content[0].type).toBe('image');
+    });
+
+    it('rejects a chunked remote image over 10 MB with no content-length', async () => {
+      // Stream 40 MB in 1 MB chunks with no Content-Length header, so the header
+      // pre-check cannot catch it and the cap has to be enforced on the bytes
+      // actually received. The server must not get to serve the whole body: the
+      // download has to be cancelled as soon as the cap is crossed.
+      let chunksServed = 0;
+      const imgServer = createMockServer({
+        routes: {
+          '/chunked.png': () => new Response(new ReadableStream({
+            pull(controller) {
+              if (chunksServed >= 40) { controller.close(); return; }
+              chunksServed++;
+              controller.enqueue(new Uint8Array(1024 * 1024));
+            },
+          }), { headers: { 'Content-Type': 'image/png' } }),
+        },
+      });
+
+      try {
+        await expect(
+          dryRunRequest(baseConfig, { message: ['hi'], image: [`${imgServer.url}/chunked.png`] }),
+        ).rejects.toThrow(/too large/i);
+        expect(chunksServed).toBeLessThan(40);
+      } finally {
+        imgServer.close();
+      }
+    });
+
+    it('rejects when the serialized request body exceeds 64 MB even if the images fit', async () => {
+      // 40 MB of double quotes is under the cap as raw text, but JSON-escapes to
+      // 80 MB on the wire; only a check on the serialized body catches that.
+      const system = '"'.repeat(40 * 1024 * 1024);
+
+      await expect(
+        dryRunRequest(baseConfig, { system, message: ['hi'], image: [imgA] }),
+      ).rejects.toThrow(/64 MB/);
+    });
+
     it('rejects when images cumulatively exceed the 64 MB request cap', async () => {
       // ~7.15 MB decoded each — under the 10 MB per-image cap, but seven of
       // them push the whole request past the 64 MB aggregate cap.


### PR DESCRIPTION
Closes #224.

## What

`mmx text chat` now takes a repeatable `--image <path-or-url>`:

```bash
# single image
mmx text chat --image ./photo.jpg --message "What breed is this dog?"

# multiple images in one call
mmx text chat --image ./before.png --image ./after.png \
  --message "List every visual difference between these two."
```

## Why

M3 is multimodal and already accepts multiple images through `--messages-file`, but there was no CLI path to it, you had to hand-write a base64 messages JSON. Worse, the documented OpenAI shape (`{"type":"image_url", ...}`) is rejected, because `text chat` posts to the Anthropic-compatible `/anthropic/v1/messages` endpoint and needs `{"type":"image","source":{"type":"base64",...}}`. `--image` emits the right shape for you.

## How

- `toImageBlock()` in `src/utils/image.ts` wraps `toDataUri()` and enforces the M3 image contract: each image is capped at 10 MB, formats are restricted to JPEG/PNG/GIF/WEBP, and oversized files are rejected before encoding (via `statSync` for local paths, `content-length` checks for remote URLs, and size computation for data URIs).
- `src/commands/text/chat.ts` appends image blocks to the last user message, promoting `content` from a string to a block array. Text goes first so the model reads the instruction before the pixels. With no `--message`, images become the user message.
- The aggregate request body is tracked and capped at 64 MB, so runs bail as soon as an image would exceed the limit rather than after fetching and encoding everything.
- When `--image` is present and `--model` is not, the model resolves to `MiniMax-M3`, otherwise a text-only `defaultTextModel` in config would silently break every image request. An explicit `--model` still wins.
- Docs updated: `README.md`, `README_CN.md`, and `skill/SKILL.md` (which also now calls out the OpenAI-vs-Anthropic block-shape gotcha).
- `ContentBlock` type gains the `image` variant.

## Verification

Dry run of the built binary:

```console
$ mmx text chat --image a.png --image b.png --message "diff these" --dry-run --output json
{
  "request": {
    "model": "MiniMax-M3",
    "messages": [ { "role": "user", "content": [
      { "type": "text",  "text": "diff these" },
      { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "..." } },
      { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "..." } }
    ] } ],
    "max_tokens": 4096,
    "stream": false
  }
}
```

That is byte-for-byte the payload shape confirmed working against M3 in #224.

Six focused test categories in `test/commands/text/chat.test.ts` cover block shape, multi-image, image-without-message, model override, explicit `--model` winning, missing file, oversized local file, unsupported format (HEIC), supported format (GIF), remote image over the per-image cap, data URI over cap, and seven small images that cumulatively exceed the 64 MB cap. `bun test` 461 pass / 0 fail; `bun run typecheck` and `bun run lint` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788479780&installation_model_id=427615&pr_number=225&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F225&signature=730b8e4318122542d41cfd99317362c40209d19001612ffcdeb2382e7d2a5d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
