### PR TITLE
refactor: share file upload operation

### DIFF
--- a/src/commands/file/upload.ts
+++ b/src/commands/file/upload.ts
@@ -2,16 +2,13 @@ import { defineCommand } from '../../command';
 import { CLIError } from '../../errors/base';
 import { ExitCode } from '../../errors/codes';
 import { requestJson } from '../../client/http';
-import { fileUploadEndpoint } from '../../client/endpoints';
+import { resolveFileUploadPath, uploadFile } from '../../files/upload';
 import { formatOutput, detectOutputFormat } from '../../output/formatter';
 import { isInteractive } from '../../utils/env';
 import { promptText, failIfMissing } from '../../utils/prompt';
 import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { FileUploadResponse } from '../../types/api';
-import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
-import { resolve, basename } from 'path';
 
 export default defineCommand({
   name: 'file upload',
@@ -40,10 +37,9 @@ export default defineCommand({
       }
     }
 
-    const fullPath = resolve(filePath);
-    if (!existsSync(fullPath)) {
-      throw new CLIError(`File not found: ${fullPath}`, ExitCode.USAGE);
-    }
+    const createFileNotFoundError = (fullPath: string) =>
+      new CLIError(`File not found: ${fullPath}`, ExitCode.USAGE);
+    const fullPath = resolveFileUploadPath(filePath, createFileNotFoundError);
 
     const purpose = (flags.purpose as string) || 'retrieval';
     const format = detectOutputFormat(config.output);
@@ -53,19 +49,12 @@ export default defineCommand({
       return;
     }
 
-    const formData = new FormData();
-    // Read file using Node.js fs/promises (compatible with both Node and Bun)
-    const fileData = await readFile(fullPath);
-    const fileName = basename(fullPath);
-    const fileBlob = new Blob([fileData]);
-    formData.append('file', fileBlob, fileName);
-    formData.append('purpose', purpose);
-
-    const url = fileUploadEndpoint(config.baseUrl);
-    const response = await requestJson<FileUploadResponse>(config, {
-      url,
-      method: 'POST',
-      body: formData,
+    const response = await uploadFile({
+      filePath: fullPath,
+      purpose,
+      baseUrl: config.baseUrl,
+      requestJson: (opts) => requestJson<FileUploadResponse>(config, opts),
+      createFileNotFoundError,
     });
 
     if (config.quiet) {

--- a/src/files/upload.ts
+++ b/src/files/upload.ts
@@ -1,0 +1,49 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+import { fileUploadEndpoint } from '../client/endpoints';
+import type { RequestOpts } from '../client/http';
+import type { FileUploadResponse } from '../types/api';
+
+type RequestFileUpload = (opts: RequestOpts) => Promise<FileUploadResponse>;
+type CreateFileNotFoundError = (fullPath: string) => Error;
+
+interface UploadFileOptions {
+  filePath: string;
+  purpose: string;
+  baseUrl: string;
+  requestJson: RequestFileUpload;
+  createFileNotFoundError: CreateFileNotFoundError;
+}
+
+export function resolveFileUploadPath(
+  filePath: string,
+  createFileNotFoundError: CreateFileNotFoundError,
+): string {
+  const fullPath = resolve(filePath);
+  if (!existsSync(fullPath)) {
+    throw createFileNotFoundError(fullPath);
+  }
+  return fullPath;
+}
+
+export async function uploadFile({
+  filePath,
+  purpose,
+  baseUrl,
+  requestJson,
+  createFileNotFoundError,
+}: UploadFileOptions): Promise<FileUploadResponse> {
+  const fullPath = resolveFileUploadPath(filePath, createFileNotFoundError);
+  const fileData = await readFile(fullPath);
+
+  const formData = new FormData();
+  formData.append('file', new Blob([fileData]), basename(fullPath));
+  formData.append('purpose', purpose);
+
+  return requestJson({
+    url: fileUploadEndpoint(baseUrl),
+    method: 'POST',
+    body: formData,
+  });
+}

--- a/src/sdk/file/index.ts
+++ b/src/sdk/file/index.ts
@@ -1,13 +1,10 @@
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { resolve, basename } from 'node:path';
 import { Client } from '../client';
 import {
-  fileUploadEndpoint,
   fileListEndpoint,
   fileDeleteEndpoint,
   fileRetrieveEndpoint,
 } from '../../client/endpoints';
+import { uploadFile } from '../../files/upload';
 import type {
   FileUploadResponse,
   FileListResponse,
@@ -25,23 +22,13 @@ export class FileSDK extends Client {
    * @param purpose  - File purpose, defaults to `"retrieval"`.
    */
   async upload(filePath: string, purpose = 'retrieval'): Promise<FileUploadResponse> {
-    const fullPath = resolve(filePath);
-    if (!existsSync(fullPath)) {
-      throw new SDKError(`File not found: ${fullPath}`, ExitCode.USAGE);
-    }
-
-    const fileData = await readFile(fullPath);
-    const fileName = basename(fullPath);
-
-    const formData = new FormData();
-    formData.append('file', new Blob([fileData]), fileName);
-    formData.append('purpose', purpose);
-
-    const url = fileUploadEndpoint(this.config.baseUrl);
-    return this.requestJson<FileUploadResponse>({
-      url,
-      method: 'POST',
-      body: formData,
+    return uploadFile({
+      filePath,
+      purpose,
+      baseUrl: this.config.baseUrl,
+      requestJson: (opts) => this.requestJson<FileUploadResponse>(opts),
+      createFileNotFoundError: (fullPath) =>
+        new SDKError(`File not found: ${fullPath}`, ExitCode.USAGE),
     });
   }
 

--- a/test/commands/file/upload.test.ts
+++ b/test/commands/file/upload.test.ts
@@ -58,9 +58,19 @@ describe('file upload command', () => {
   });
 
   it('throws when file does not exist', async () => {
-    await expect(
-      uploadCommand.execute(baseConfig, { ...baseFlags, file: '/tmp/nonexistent-file-xxxxx.bin' }),
-    ).rejects.toThrow('File not found');
+    try {
+      await uploadCommand.execute(baseConfig, {
+        ...baseFlags,
+        file: '/tmp/nonexistent-file-xxxxx.bin',
+      });
+      throw new Error('Expected upload to reject');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'CLIError',
+        message: expect.stringContaining('File not found'),
+        exitCode: 2,
+      });
+    }
   });
 
   it('shows dry-run output with file info', async () => {
@@ -79,6 +89,59 @@ describe('file upload command', () => {
       expect(captured).toContain(filePath);
       expect(captured).toContain('vision');
     } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uploads through the shared multipart operation and formats the response', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'mmx-upload-test-'));
+    const filePath = join(tempDir, 'fixture.txt');
+    writeFileSync(filePath, 'shared upload contents');
+    const originalFetch = globalThis.fetch;
+    let requestUrl = '';
+    let requestInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (input, init) => {
+      requestUrl = String(input);
+      requestInit = init;
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        file: {
+          file_id: 'cli-file-id',
+          bytes: 22,
+          created_at: 1,
+          filename: 'fixture.txt',
+          purpose: 'vision',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    try {
+      const captured = await captureStdout(async () => {
+        await uploadCommand.execute(baseConfig, {
+          ...baseFlags,
+          file: filePath,
+          purpose: 'vision',
+        });
+      });
+
+      expect(requestUrl).toBe('https://api.mmx.io/v1/files/upload');
+      expect(requestInit?.method).toBe('POST');
+      expect(requestInit?.headers).toMatchObject({ Authorization: 'Bearer test-key' });
+      expect(requestInit?.body).toBeInstanceOf(FormData);
+
+      const body = requestInit?.body as FormData;
+      const uploadedFile = body.get('file');
+      expect(uploadedFile).toBeInstanceOf(Blob);
+      expect((uploadedFile as File).name).toBe('fixture.txt');
+      expect(await (uploadedFile as Blob).text()).toBe('shared upload contents');
+      expect(body.get('purpose')).toBe('vision');
+      expect(captured).toContain('cli-file-id');
+    } finally {
+      globalThis.fetch = originalFetch;
       rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/test/sdk/file.test.ts
+++ b/test/sdk/file.test.ts
@@ -7,23 +7,61 @@ import { tmpdir } from 'node:os';
 describe('FileSDK', () => {
   it('throws SDKError when file does not exist', async () => {
     const sdk = new FileSDK({ apiKey: 'sk-test', region: 'global' });
-    await expect(sdk.upload('/tmp/nonexistent-file-xxxxx.bin', 'retrieval'))
-      .rejects
-      .toThrow('File not found');
+    try {
+      await sdk.upload('/tmp/nonexistent-file-xxxxx.bin', 'retrieval');
+      throw new Error('Expected upload to reject');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'SDKError',
+        message: expect.stringContaining('File not found'),
+        exitCode: 2,
+      });
+    }
   });
 
-  it('gets past file existence check for a valid file', async () => {
+  it('uploads through the shared multipart operation and returns the response', async () => {
     const tmpFile = join(tmpdir(), 'mmx-sdk-test-upload.txt');
     writeFileSync(tmpFile, 'hello world');
+    const originalFetch = globalThis.fetch;
+    let requestUrl = '';
+    let requestInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (input, init) => {
+      requestUrl = String(input);
+      requestInit = init;
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        file: {
+          file_id: 'sdk-file-id',
+          bytes: 11,
+          created_at: 1,
+          filename: 'mmx-sdk-test-upload.txt',
+          purpose: 'retrieval',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
 
     try {
       const sdk = new FileSDK({ apiKey: 'sk-test', region: 'global' });
-      await sdk.upload(tmpFile, 'retrieval');
-      // Should not reach here (no mock server), but if it does, fail informatively
-    } catch (err) {
-      // Must NOT be "File not found" — proves file existence check passed
-      expect((err as Error).message).not.toContain('File not found');
+      const response = await sdk.upload(tmpFile, 'retrieval');
+
+      expect(response.file.file_id).toBe('sdk-file-id');
+      expect(requestUrl).toBe('https://api.minimax.io/v1/files/upload');
+      expect(requestInit?.method).toBe('POST');
+      expect(requestInit?.headers).toMatchObject({ Authorization: 'Bearer sk-test' });
+      expect(requestInit?.body).toBeInstanceOf(FormData);
+
+      const body = requestInit?.body as FormData;
+      const uploadedFile = body.get('file');
+      expect(uploadedFile).toBeInstanceOf(Blob);
+      expect((uploadedFile as File).name).toBe('mmx-sdk-test-upload.txt');
+      expect(await (uploadedFile as Blob).text()).toBe('hello world');
+      expect(body.get('purpose')).toBe('retrieval');
     } finally {
+      globalThis.fetch = originalFetch;
       if (existsSync(tmpFile)) unlinkSync(tmpFile);
     }
   });


### PR DESCRIPTION
## What changed

- Extract the file upload path validation, multipart construction, endpoint selection, and request execution into one internal operation.
- Reuse that operation from both the CLI command and FileSDK.
- Keep CLI prompting, dry-run, quiet output, and SDK-specific errors unchanged.

## Why

The CLI and SDK previously maintained separate upload implementations, so fixes could land in one path and be missed in the other.

## Impact

CLI and SDK behavior stays compatible while the upload protocol now has a single implementation and stronger multipart coverage.

## Checks

- `bun test` — 450 passed
- `bun run typecheck`
- `bun run build`
- `bun run lint` — no errors; one pre-existing test warning
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788522959&installation_model_id=427615&pr_number=229&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F229&signature=6373d0c235f45f3df33eb62044fb0fae5e74c8d5cf01bbc85a01c820617b1be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->