### PR TITLE
refactor: share SDK client context

### DIFF
--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -1,13 +1,14 @@
 import { loadConfig } from "../config/loader";
-import { Config } from "../config/schema";
-import { request as requestClient, requestJson as requestJsonClient, RequestOpts } from "../client/http";
+import type { Config } from "../config/schema";
+import { request as requestClient, requestJson as requestJsonClient } from "../client/http";
+import type { RequestOpts } from "../client/http";
 import { parseSSE } from "../client/stream";
 import { SDKError } from "../errors/base";
 import { ExitCode } from "../errors/codes";
-import { MiniMaxSDKOptions } from "./types";
+import type { MiniMaxSDKOptions } from "./types";
 
-export class Client {
-  protected config: Config;
+export class ClientContext {
+  readonly config: Config;
 
   constructor(options: MiniMaxSDKOptions) {
     const { apiKey, region, baseUrl } = options;
@@ -24,6 +25,18 @@ export class Client {
       nonInteractive: false,
       async: false,
     });
+  }
+}
+
+export class Client {
+  protected readonly context: ClientContext;
+  protected readonly config: Config;
+
+  constructor(optionsOrContext: MiniMaxSDKOptions | ClientContext) {
+    this.context = optionsOrContext instanceof ClientContext
+      ? optionsOrContext
+      : new ClientContext(optionsOrContext);
+    this.config = this.context.config;
   }
 
   protected request(opts: RequestOpts) {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -8,7 +8,7 @@ import { VisionSDK } from "./vision";
 import { QuotaSDK } from "./quota";
 import { FileSDK } from "./file";
 import { Client } from "./client";
-import { MiniMaxSDKOptions } from "./types";
+import type { MiniMaxSDKOptions } from "./types";
 
 export class MiniMaxSDK extends Client {
   readonly text: TextSDK;
@@ -23,14 +23,14 @@ export class MiniMaxSDK extends Client {
 
   constructor(options: MiniMaxSDKOptions) {
     super(options);
-    this.text = new TextSDK(options);
-    this.speech = new SpeechSDK(options);
-    this.image = new ImageSDK(options);
-    this.video = new VideoSDK(options);
-    this.music = new MusicSDK(options);
-    this.search = new SearchSDK(options);
-    this.vision = new VisionSDK(options);
-    this.quota = new QuotaSDK(options);
-    this.file = new FileSDK(options);
+    this.text = new TextSDK(this.context);
+    this.speech = new SpeechSDK(this.context);
+    this.image = new ImageSDK(this.context);
+    this.video = new VideoSDK(this.context);
+    this.music = new MusicSDK(this.context);
+    this.search = new SearchSDK(this.context);
+    this.vision = new VisionSDK(this.context);
+    this.quota = new QuotaSDK(this.context);
+    this.file = new FileSDK(this.context);
   }
 }

--- a/test/sdk/client.test.ts
+++ b/test/sdk/client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { Config } from '../../src/config/schema';
+import { MiniMaxSDK } from '../../src/sdk';
+import { TextSDK } from '../../src/sdk/text';
+import { createMockServer, jsonResponse, type MockServer } from '../helpers/mock-server';
+
+interface ClientState {
+  context: object;
+  config: Config;
+}
+
+function clientState(client: object): ClientState {
+  return client as ClientState;
+}
+
+describe('SDK client context', () => {
+  let server: MockServer;
+
+  afterEach(() => {
+    server?.close();
+  });
+
+  it('shares one resolved context and config across all child SDKs', () => {
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: 'https://example.com',
+    });
+    const rootState = clientState(sdk);
+    const childClients = [
+      sdk.text,
+      sdk.speech,
+      sdk.image,
+      sdk.video,
+      sdk.music,
+      sdk.search,
+      sdk.vision,
+      sdk.quota,
+      sdk.file,
+    ];
+
+    for (const child of childClients) {
+      expect(clientState(child).context).toBe(rootState.context);
+      expect(clientState(child).config).toBe(rootState.config);
+    }
+
+    expect(rootState.config.apiKey).toBe('test-key');
+    expect(rootState.config.baseUrl).toBe('https://example.com');
+  });
+
+  it('preserves direct child SDK construction and request behavior', async () => {
+    server = createMockServer({
+      routes: {
+        '/anthropic/v1/messages': () => jsonResponse({
+          id: 'msg-direct',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello!' }],
+          model: 'MiniMax-M3',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      },
+    });
+
+    const sdk = new TextSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+    const result = await sdk.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+
+    expect(result.id).toBe('msg-direct');
+  });
+});


### PR DESCRIPTION
## What changed

- Add a shared SDK client context that resolves configuration once.
- Reuse the same context and config across all MiniMaxSDK child modules.
- Preserve direct construction of individual SDK modules with MiniMaxSDKOptions.

## Why

Constructing MiniMaxSDK previously rebuilt the same configuration independently for every child SDK.

## Impact

All child SDKs now observe one consistent configuration snapshot without breaking standalone SDK module usage.

## Checks

- `bun test` — 451 passed
- `bun run typecheck`
- `bun run lint` — no errors; one pre-existing test warning
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788522959&installation_model_id=427615&pr_number=230&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F230&signature=bb5a0698c4fbfd24aa3949ad2e182be8be5444551ed96ae30f0ef878df86a9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->