### PR TITLE
feat(text): expose MiniMax-M2.7 in model help

### DIFF
--- a/src/commands/text/chat.ts
+++ b/src/commands/text/chat.ts
@@ -17,6 +17,7 @@ import type {
 import { readFileSync } from 'fs';
 import { isInteractive } from '../../utils/env';
 import { promptText, failIfMissing } from '../../utils/prompt';
+import { DEFAULT_TEXT_MODEL, TEXT_MODELS } from './models';
 
 // ---------------------------------------------------------------------------
 // Thinking indicator — dynamic spinner + color-cycling label
@@ -159,7 +160,10 @@ export default defineCommand({
   apiDocs: '/docs/api-reference/text-post',
   usage: 'mmx text chat --message <text> [flags]',
   options: [
-    { flag: '--model <model>', description: 'Model ID (default: MiniMax-M3)' },
+    {
+      flag: '--model <model>',
+      description: `Model ID (default: ${DEFAULT_TEXT_MODEL}; supported: ${TEXT_MODELS.join(', ')})`,
+    },
     { flag: '--message <text>',        description: 'Message text (repeatable, prefix role: to set role)', required: true, type: 'array' },
     { flag: '--messages-file <path>',  description: 'JSON file with messages array (use - for stdin)' },
     { flag: '--system <text>',         description: 'System prompt' },
@@ -197,7 +201,7 @@ export default defineCommand({
 
     const model = (flags.model as string)
       || config.defaultTextModel
-      || 'MiniMax-M3';
+      || DEFAULT_TEXT_MODEL;
     const format = detectOutputFormat(config.output);
     const shouldStream = flags.stream === true || (
       flags.stream === undefined

--- a/src/commands/text/models.ts
+++ b/src/commands/text/models.ts
@@ -1,0 +1,6 @@
+export const TEXT_MODELS = [
+  'MiniMax-M3',
+  'MiniMax-M2.7',
+] as const;
+
+export const DEFAULT_TEXT_MODEL = TEXT_MODELS[0];

--- a/src/commands/text/repl.ts
+++ b/src/commands/text/repl.ts
@@ -9,6 +9,7 @@ import type { Config } from '../../config/schema';
 import type { GlobalFlags } from '../../types/flags';
 import type { ChatMessage, ChatRequest, StreamEvent } from '../../types/api';
 import { writeFileSync } from 'node:fs';
+import { DEFAULT_TEXT_MODEL, TEXT_MODELS } from './models';
 
 // ---------------------------------------------------------------------------
 // ANSI helpers
@@ -294,7 +295,10 @@ export default defineCommand({
   description: 'Start an interactive multi-turn chat session',
   usage: 'mmx text repl [flags]',
   options: [
-    { flag: '--model <model>',     description: 'Model ID (default: MiniMax-M3)' },
+    {
+      flag: '--model <model>',
+      description: `Model ID (default: ${DEFAULT_TEXT_MODEL}; supported: ${TEXT_MODELS.join(', ')})`,
+    },
     { flag: '--system <text>',     description: 'System prompt' },
     { flag: '--max-tokens <n>',    description: 'Maximum tokens per response (default: 4096)', type: 'number' },
     { flag: '--temperature <n>',   description: 'Sampling temperature (0.0, 1.0]', type: 'number' },
@@ -325,7 +329,7 @@ export default defineCommand({
     const state: ReplState = {
       messages: [],
       system: flags.system as string | undefined,
-      model: (flags.model as string) || config.defaultTextModel || 'MiniMax-M3',
+      model: (flags.model as string) || config.defaultTextModel || DEFAULT_TEXT_MODEL,
       maxTokens: (flags.maxTokens as number) ?? 4096,
       temperature: flags.temperature !== undefined ? flags.temperature as number : undefined,
       topP: flags.topP !== undefined ? flags.topP as number : undefined,

--- a/src/sdk/text/index.ts
+++ b/src/sdk/text/index.ts
@@ -3,6 +3,7 @@ import { chatEndpoint } from "../../client/endpoints";
 import { ChatRequest, ChatResponse, StreamEvent } from "../../types/api";
 import { SDKError } from "../../errors/base";
 import { ExitCode } from "../../errors/codes";
+import { DEFAULT_TEXT_MODEL } from "../../commands/text/models";
 
 export class TextSDK extends Client {
   private async *chatStream(body: Partial<ChatRequest>): AsyncGenerator<StreamEvent> {
@@ -56,7 +57,7 @@ export class TextSDK extends Client {
 
     return {
       ...params,
-      model: params.model ?? 'MiniMax-M3',
+      model: params.model ?? DEFAULT_TEXT_MODEL,
       max_tokens: params.max_tokens ?? 4096,
     } as ChatRequest;
   }

--- a/test/commands/text/chat.test.ts
+++ b/test/commands/text/chat.test.ts
@@ -302,4 +302,12 @@ describe('text chat command', () => {
       console.log = originalLog;
     }
   });
+
+  it('lists supported models in --model help', async () => {
+    const { default: chatCommand } = await import('../../../src/commands/text/chat');
+    const modelOption = chatCommand.options?.find(option => option.flag.includes('--model'));
+
+    expect(modelOption?.description).toContain('MiniMax-M3');
+    expect(modelOption?.description).toContain('MiniMax-M2.7');
+  });
 });

--- a/test/commands/text/models.test.ts
+++ b/test/commands/text/models.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  DEFAULT_TEXT_MODEL,
+  TEXT_MODELS,
+} from '../../../src/commands/text/models';
+
+describe('text models', () => {
+  it('registers supported models in default order', () => {
+    expect(TEXT_MODELS).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+    expect(DEFAULT_TEXT_MODEL).toBe('MiniMax-M3');
+  });
+});

--- a/test/commands/text/repl.test.ts
+++ b/test/commands/text/repl.test.ts
@@ -57,4 +57,12 @@ describe('text repl command', () => {
 
     await expect(cmd.execute(config, flags)).rejects.toThrow('interactive');
   });
+
+  it('lists supported models in --model help', async () => {
+    const mod = await import('../../../src/commands/text/repl');
+    const modelOption = mod.default.options?.find(option => option.flag.includes('--model'));
+
+    expect(modelOption?.description).toContain('MiniMax-M3');
+    expect(modelOption?.description).toContain('MiniMax-M2.7');
+  });
 });


### PR DESCRIPTION
Reason: MiniMax-M2.7 is accepted by the text commands but was not listed in a shared model registry or CLI help.

## Changes

- Add a shared text model registry with MiniMax-M3 as the default and MiniMax-M2.7 as a supported option.
- Use the shared default in text chat, text repl, and the text SDK.
- List both supported models in text command help and add focused registry and help coverage.
- Preserve the existing pass-through behavior for explicit model IDs.

## Checks

- `bun run lint` (0 errors; 1 pre-existing warning)
- `bun run typecheck`
- `bun test test/commands/text/models.test.ts test/commands/text/chat.test.ts test/commands/text/repl.test.ts test/sdk/text.test.ts` (15 pass, 0 fail)
- `bun test` with isolated MiniMax configuration (466 pass, 0 fail)
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789018196&installation_model_id=427615&pr_number=236&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F236&signature=b63b6a99fe35443dea23893c97b5277ae1e5f1e248870c3835e448ab2868034a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->