### PR TITLE
feat(text chat): add typed video content blocks

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,7 +1,25 @@
 // ---- Text / Chat (Anthropic Messages API) ----
 
+export type VideoSource =
+  | {
+      type: 'url';
+      url: string;
+      detail?: 'low' | 'default' | 'high';
+      fps?: number;
+      max_long_side_pixel?: number;
+    }
+  | {
+      type: 'base64';
+      media_type: string;
+      data: string;
+      detail?: 'low' | 'default' | 'high';
+      fps?: number;
+      max_long_side_pixel?: number;
+    };
+
 export type ContentBlock =
   | { type: 'text'; text: string }
+  | { type: 'video'; source: VideoSource }
   | { type: 'thinking'; thinking: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string };

--- a/test/sdk/text.test.ts
+++ b/test/sdk/text.test.ts
@@ -37,6 +37,70 @@ describe('MiniMaxSDK.text', () => {
     expect(result.id).toBe('msg-123');
   });
 
+  it('passes video content blocks through to chat requests', async () => {
+    let requestBody: unknown;
+    server = createMockServer({
+      routes: {
+        '/anthropic/v1/messages': async request => {
+          requestBody = await request.json();
+          return jsonResponse({
+            id: 'msg-video',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'A short clip.' }],
+            model: 'MiniMax-M3',
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 20, output_tokens: 4 },
+          });
+        },
+      },
+    });
+
+    const sdk = new MiniMaxSDK({
+      apiKey: 'test-key',
+      baseUrl: server.url,
+    });
+
+    await sdk.text.chat({
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What happens in this clip?' },
+          {
+            type: 'video',
+            source: {
+              type: 'url',
+              url: 'https://example.com/clip.mp4',
+              detail: 'high',
+              fps: 0.5,
+              max_long_side_pixel: 1280,
+            },
+          },
+        ],
+      }],
+    });
+
+    expect(requestBody).toMatchObject({
+      model: 'MiniMax-M3',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What happens in this clip?' },
+          {
+            type: 'video',
+            source: {
+              type: 'url',
+              url: 'https://example.com/clip.mp4',
+              detail: 'high',
+              fps: 0.5,
+              max_long_side_pixel: 1280,
+            },
+          },
+        ],
+      }],
+    });
+  });
+
   it('streaming skips empty SSE data events', async () => {
     const chunk = JSON.stringify({
       type: 'content_block_delta',


### PR DESCRIPTION
Reason: Add MiniMax-M3 video content blocks to typed text chat requests.

## Changes

- Add URL and base64 video sources to the Messages API content-block types.
- Preserve video detail, frame sampling, and maximum-dimension options in chat payloads.
- Verify that the text SDK sends a complete video block to the chat endpoint.

## Checks

- `bun test test/sdk/text.test.ts`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789163511&installation_model_id=427615&pr_number=238&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F238&signature=a8442689050a337e06bb0cdb6b9b792155a5a2bf5c977bf695fbac260acb6f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->