### PR TITLE
ci: use MiniMax-M3 for PR reviews

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Claude Code review
         uses: anthropics/claude-code-action@v1.0.102
         env:
-          ANTHROPIC_BASE_URL: https://api.minimax.io/anthropic
+          ANTHROPIC_BASE_URL: https://api.minimaxi.com/anthropic
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -90,7 +90,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --model MiniMax-M2.7-highspeed
+            --model MiniMax-M3
             --max-turns 300
             --allowed-tools Read,Glob,Grep
           prompt: |


### PR DESCRIPTION
## Summary

- switch AI PR review from `MiniMax-M2.7-highspeed` to `MiniMax-M3`
- use the MiniMax CN Anthropic-compatible endpoint for the configured Actions API key

## Validation

- verified `MiniMax-M3` authentication with a minimal request against the CN endpoint
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790510707&installation_model_id=427615&pr_number=244&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F244&signature=16d18b7aa590ce5a6f19d719ac6c7e9817b804a49471cd62f7023c8d0eb448b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->