### PR TITLE
fix: honor configured quota output format

### DIFF
--- a/src/commands/quota/show.ts
+++ b/src/commands/quota/show.ts
@@ -17,13 +17,13 @@ export default defineCommand({
     'mmx quota show',
     'mmx quota show --output json',
   ],
-  async run(config: Config, flags: GlobalFlags) {
+  async run(config: Config, _flags: GlobalFlags) {
     if (config.dryRun) {
       console.log('Would fetch quota information.');
       return;
     }
 
-    const format = detectOutputFormat(flags.output as string | undefined);
+    const format = detectOutputFormat(config.output);
     const credential = await resolveCredential(config);
     const endpoint = selectUsageEndpoint(config.baseUrl, credential);
 

--- a/test/commands/quota/show.test.ts
+++ b/test/commands/quota/show.test.ts
@@ -62,6 +62,39 @@ describe('quota show command', () => {
     }
   });
 
+  it('honors JSON output resolved from config without an output flag', async () => {
+    server = createMockServer({
+      routes: {
+        '/v1/token_plan/remains': () => jsonResponse({
+          model_remains: [],
+          base_resp: { status_code: 0, status_msg: 'ok' },
+        }),
+      },
+    });
+
+    const output: string[] = [];
+    const originalLog = console.log;
+    const ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    console.log = (message?: unknown) => { output.push(String(message ?? '')); };
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+    try {
+      await showCommand.execute(
+        { ...baseConfig, baseUrl: server.url, output: 'json' },
+        { ...baseFlags, output: undefined },
+      );
+    } finally {
+      console.log = originalLog;
+      if (ttyDescriptor) {
+        Object.defineProperty(process.stdout, 'isTTY', ttyDescriptor);
+      } else {
+        delete (process.stdout as unknown as Record<string, unknown>).isTTY;
+      }
+    }
+
+    expect(JSON.parse(output.join('\n'))).toMatchObject({ model_remains: [] });
+  });
+
   it('uses account/query_balance for sk-api keys', async () => {
     server = createMockServer({
       routes: {


### PR DESCRIPTION
## Summary

- use the resolved config output for quota responses
- honor explicit flags, MINIMAX_OUTPUT, and saved config consistently
- add a TTY regression test while preserving credential routing and quota count handling

Supersedes #209. Thanks @shaoohh for identifying the issue and the original fix direction.

## Validation

- npx bun test (415 passed)
- npx bun run typecheck
- npx bun run lint (one pre-existing warning)
- npx bun run build:dev
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516527&installation_model_id=427615&pr_number=246&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F246&signature=f8d810035b72fcb96d825a49803815b6fc5792b6f7e368f00951d7aa97c854c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->