### PR TITLE
fix: include README in npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           trap 'rm -rf "$staging_dir"' EXIT
 
           cp package.json "$staging_dir/package.json"
+          cp README.md "$staging_dir/README.md"
           cp -R dist "$staging_dir/dist"
           node -e '
             const fs = require("fs");


### PR DESCRIPTION
## What changed

- Include README.md in the npm release staging directory.

## Why

The published npm package currently has no README.

## Tests

- Build passed.
- The packed tarball contains package/README.md.
- Typecheck passed.
- 503 tests passed.
- Lint passed with 0 errors and 1 existing warning.
- Two independent blind reviews returned CLEAN.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790838345&installation_model_id=427615&pr_number=250&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F250&signature=5961c957d490576b2cc9cc79085fd757fc130e5f837ff4e5d8391b4d3c8671e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->