### PR TITLE
fix: detect Codex runtime in desktop app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,13 @@ describe('auth/login', () => {
 - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 - Keep commits atomic and focused
 
+### Blind Review
+
+- After implementation, send the full diff to two independent reviewers. Give them only the requirements, acceptance criteria, and task boundaries; do not reveal the implementation intent or the other reviewer's findings.
+- Fix confirmed issues with scoped changes, then repeat the two independent reviews.
+- Once reviews converge and only small corrections remain, use one blind reviewer.
+- If review and fixes stop converging, pause patching and reconsider the design as a whole. Stop and report the unresolved issue if redesign does not resolve it.
+
 ## Project Structure
 
 ```

--- a/src/agent/availability.ts
+++ b/src/agent/availability.ts
@@ -36,3 +36,9 @@ export function detectAgentsOnPath(env: NodeJS.ProcessEnv = process.env): Set<Ag
     })),
   )));
 }
+
+export function detectAvailableAgents(env: NodeJS.ProcessEnv = process.env): Set<AgentId> {
+  const agents = detectAgentsOnPath(env);
+  if (env.CODEX_THREAD_ID?.trim()) agents.add('codex');
+  return agents;
+}

--- a/src/commands/agent/setup.ts
+++ b/src/commands/agent/setup.ts
@@ -6,7 +6,7 @@ import {
   prepareAgentConfigurations,
   withAgentSetupLock,
 } from '../../agent/configurator';
-import { detectAgentsOnPath } from '../../agent/availability';
+import { detectAvailableAgents } from '../../agent/availability';
 import {
   getAgentInstallCommand,
   getAgentInstallIssue,
@@ -412,7 +412,7 @@ export default defineCommand({
     'mmx agent setup --agent opencode --api-key <key> --region cn --dry-run',
   ],
   async run(config: Config, flags: GlobalFlags) {
-    const detectedAgents = detectAgentsOnPath();
+    const detectedAgents = detectAvailableAgents();
     const interactive = isInteractiveInvocation(flags);
     const options = interactive
       ? await interactiveOptions(config, detectedAgents)

--- a/test/agent/availability.test.ts
+++ b/test/agent/availability.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { detectAgentsOnPath } from '../../src/agent/availability';
+import { detectAgentsOnPath, detectAvailableAgents } from '../../src/agent/availability';
 
 describe('agent availability', () => {
   const roots: string[] = [];
@@ -59,5 +59,27 @@ describe('agent availability', () => {
     const root = executableDirectory('pi');
 
     expect(detectAgentsOnPath({ Path: root })).toEqual(new Set());
+  });
+
+  it('recognizes the active Codex runtime without a Codex executable on PATH', () => {
+    expect(detectAvailableAgents({ CODEX_THREAD_ID: 'thread-id' })).toEqual(new Set(['codex']));
+  });
+
+  it('keeps PATH detection when recognizing the active Codex runtime', () => {
+    const root = executableDirectory('pi');
+    expect(detectAvailableAgents({
+      PATH: root,
+      PATHEXT: '.COM;.EXE;.BAT;.CMD',
+      CODEX_THREAD_ID: 'thread-id',
+    })).toEqual(new Set(['codex', 'pi']));
+  });
+
+  it('does not recognize a Codex runtime when its marker is missing', () => {
+    expect(detectAvailableAgents({})).toEqual(new Set());
+  });
+
+  it('ignores empty and whitespace-only Codex runtime markers', () => {
+    expect(detectAvailableAgents({ CODEX_THREAD_ID: '' })).toEqual(new Set());
+    expect(detectAvailableAgents({ CODEX_THREAD_ID: '  ' })).toEqual(new Set());
   });
 });


### PR DESCRIPTION
## What changed

- Treat a non-empty `CODEX_THREAD_ID` as an active Codex runtime.
- Preserve the existing PATH-based detection for all coding agents.
- Cover runtime-only, PATH merge, missing, empty, and whitespace marker cases.
- Add the repository blind-review workflow used for this change.

## Scope

This PR only addresses Codex running inside ChatGPT Desktop. It does not add runtime detection for other agents or change installation and configuration behavior.

## Validation

- 500 tests passed.
- Type check passed.
- Production build passed.
- Lint passed with one existing warning in `test/sdk/speech.test.ts`.
- Final blind review found no issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790958732&installation_model_id=427615&pr_number=252&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F252&signature=a892d3a2b048784ded8f28b224aa2eba7d70b89a16d275bffb3bef798442cb25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->