### PR TITLE
fix: detect embedded agent runtimes

### DIFF
--- a/src/agent/availability.ts
+++ b/src/agent/availability.ts
@@ -12,6 +12,13 @@ const AGENT_EXECUTABLES: Record<AgentId, readonly string[]> = {
   pi: ['pi'],
 };
 
+const AGENT_RUNTIME_MARKERS: Partial<Record<AgentId, readonly [string, string]>> = {
+  'claude-code': ['CLAUDE_CODE_CHILD_SESSION', '1'],
+  opencode: ['OPENCODE_CLIENT', 'desktop'],
+  hermes: ['HERMES_AGENT', 'true'],
+  pi: ['PI_CODING_AGENT', 'true'],
+};
+
 export function detectAgentsOnPath(env: NodeJS.ProcessEnv = process.env): Set<AgentId> {
   const pathValue = process.platform === 'win32' ? env.PATH ?? env.Path : env.PATH;
   if (pathValue === undefined) return new Set();
@@ -40,5 +47,9 @@ export function detectAgentsOnPath(env: NodeJS.ProcessEnv = process.env): Set<Ag
 export function detectAvailableAgents(env: NodeJS.ProcessEnv = process.env): Set<AgentId> {
   const agents = detectAgentsOnPath(env);
   if (env.CODEX_THREAD_ID?.trim()) agents.add('codex');
+  for (const agent of AGENT_IDS) {
+    const marker = AGENT_RUNTIME_MARKERS[agent];
+    if (marker !== undefined && env[marker[0]] === marker[1]) agents.add(agent);
+  }
   return agents;
 }

--- a/test/agent/availability.test.ts
+++ b/test/agent/availability.test.ts
@@ -65,6 +65,17 @@ describe('agent availability', () => {
     expect(detectAvailableAgents({ CODEX_THREAD_ID: 'thread-id' })).toEqual(new Set(['codex']));
   });
 
+  it('recognizes supported agent runtimes from their exact markers', () => {
+    for (const [env, agent] of [
+      [{ CLAUDE_CODE_CHILD_SESSION: '1' }, 'claude-code'],
+      [{ OPENCODE_CLIENT: 'desktop' }, 'opencode'],
+      [{ HERMES_AGENT: 'true' }, 'hermes'],
+      [{ PI_CODING_AGENT: 'true' }, 'pi'],
+    ] as const) {
+      expect(detectAvailableAgents(env)).toEqual(new Set([agent]));
+    }
+  });
+
   it('keeps PATH detection when recognizing the active Codex runtime', () => {
     const root = executableDirectory('pi');
     expect(detectAvailableAgents({
@@ -81,5 +92,16 @@ describe('agent availability', () => {
   it('ignores empty and whitespace-only Codex runtime markers', () => {
     expect(detectAvailableAgents({ CODEX_THREAD_ID: '' })).toEqual(new Set());
     expect(detectAvailableAgents({ CODEX_THREAD_ID: '  ' })).toEqual(new Set());
+  });
+
+  it('does not infer runtimes from broad or near-match markers', () => {
+    expect(detectAvailableAgents({
+      CLAUDECODE: '1',
+      CLAUDE_CODE_CHILD_SESSION: 'true',
+      OPENCODE_CLIENT: 'cli',
+      HERMES_AGENT: '1',
+      PI_CODING_AGENT: '1',
+      AI_AGENT: 'pi',
+    })).toEqual(new Set());
   });
 });


### PR DESCRIPTION
## Summary

- detect Claude Code, OpenCode Desktop, Hermes, and Pi from their exact runtime markers
- preserve executable PATH detection and the existing Codex runtime detection
- reject broad, generic, and near-match environment markers to reduce false positives

## Scope

This PR only changes agent availability detection and its tests. It does not change installation, configuration, command behavior, dependencies, versions, or Grok detection.

## Validation

- targeted availability tests: 10 passed
- typecheck: passed
- lint: passed with one pre-existing warning in test/sdk/speech.test.ts
- build: passed
- full suite: 508 passed; one unrelated installer process-tree timeout test failed before writing its helper PID
- two independent blind reviews plus one final blind review: no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790959575&installation_model_id=427615&pr_number=253&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F253&signature=8c8523dcc632536dda69a9b10d5e2bf6f98f64e86183b182bbc64a033aa68f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->