### PR TITLE
fix(quota): show seconds in reset countdown

### DIFF
--- a/src/output/quota-table.ts
+++ b/src/output/quota-table.ts
@@ -49,6 +49,7 @@ function displayModelName(name: string, region: string): string {
 
 function formatDuration(ms: number, nowLabel: string): string {
   if (ms <= 0) return nowLabel;
+  if (ms < 60000) return `${Math.max(1, Math.floor(ms / 1000))}s`;
   const hours = Math.floor(ms / 3600000);
   const minutes = Math.floor((ms % 3600000) / 60000);
   return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;

--- a/test/output/quota-table.test.ts
+++ b/test/output/quota-table.test.ts
@@ -222,6 +222,39 @@ describe('renderQuotaTable', () => {
     }
   });
 
+  it('renders seconds only for positive durations below one minute', () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+
+    console.log = (message?: unknown) => {
+      lines.push(String(message ?? ''));
+    };
+
+    try {
+      renderQuotaTable(
+        [
+          { ...createModel(), model_name: 'subsecond', remains_time: 1 },
+          { ...createModel(), model_name: 'seconds', remains_time: 59_999 },
+          { ...createModel(), model_name: 'minute', remains_time: 60_000 },
+          { ...createModel(), model_name: 'elapsed', remains_time: 0 },
+        ],
+        { ...createConfig(), noColor: true },
+      );
+      renderQuotaTable(
+        [{ ...createModel(), model_name: 'expired-cn', remains_time: -1 }],
+        { ...createConfig(), region: 'cn', noColor: true },
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(lines.find(line => line.includes('subsecond'))).toContain('12h Reset 1s');
+    expect(lines.find(line => line.includes('seconds'))).toContain('12h Reset 59s');
+    expect(lines.find(line => line.includes('minute'))).toContain('12h Reset 1m');
+    expect(lines.find(line => line.includes('elapsed'))).toContain('12h Reset now');
+    expect(lines.find(line => line.includes('expired-cn'))).toContain('12h 重置 即将');
+  });
+
   it('applies weekly_boost_permille (1500 ⇒ up to 150%) when rendering weekly percent', () => {
     const lines: string[] = [];
     const originalLog = console.log;


### PR DESCRIPTION
## Summary

- show whole seconds while a positive quota reset countdown is below one minute
- preserve the existing minute/hour formatting and localized expired state
- cover subsecond, 60-second, zero, negative, and localization boundaries

## Scope

This PR only changes quota reset duration formatting and its regression coverage. It does not implement the weekly header proposed in #248 or change table layout, API behavior, JSON output, or quiet output.

## Verification

- Full test suite: 510 passed, 0 failed
- TypeScript typecheck passed
- ESLint passed with one pre-existing warning in test/sdk/speech.test.ts
- Development build passed

Closes #254

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791008830&installation_model_id=427615&pr_number=255&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F255&signature=0fcb62b3a6e7399cb603e5869c5e821aa4aa20a8d129920a2381b1562465f5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->