### PR TITLE
fix(search): map output sensitivity to content filter exit code

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -226,6 +226,7 @@ No error scenarios — prints a message directing users to run `npm update -g mm
 | HTTP 401 / 403 | `API key rejected (HTTP ${status}).` |
 | HTTP 429 | `Rate limit or quota exceeded. ${apiMsg}` |
 | `status_code` 1002 / 1039 (content filter) | `Input content flagged by sensitivity filter (${filterType}).` |
+| `status_msg` contains "new_sensitive" / output sensitivity (HTTP 200) | `Output withheld by content moderation (${apiMsg}).` |
 | `status_code` 1028 / 1030 (quota exhausted) | `Quota exhausted. ${apiMsg}` |
 | `status_code` 2061 (model not on plan) | `This model is not available on your current Token Plan. ${apiMsg}` |
 | Other API errors | `API error: ${apiMsg} (HTTP ${status})` |

--- a/src/errors/api.ts
+++ b/src/errors/api.ts
@@ -106,8 +106,8 @@ export function mapApiError(status: number, body: ApiErrorBody, url?: string): C
     );
   }
 
-  // output sensitivity (HTTP 200, e.g. "output new_sensitive")
-  if (/new_sensitive/i.test(apiMsg) || /output.*sensitive/i.test(apiMsg)) {
+  // output sensitivity (status_code 1027, e.g. "output new_sensitive")
+  if (apiCode === 1027 || /new_sensitive/i.test(apiMsg) || /output.*sensitive/i.test(apiMsg)) {
     return new CLIError(
       `Output withheld by content moderation (${apiMsg}).`,
       ExitCode.CONTENT_FILTER,

--- a/src/errors/api.ts
+++ b/src/errors/api.ts
@@ -106,6 +106,15 @@ export function mapApiError(status: number, body: ApiErrorBody, url?: string): C
     );
   }
 
+  // output sensitivity (HTTP 200, e.g. "output new_sensitive")
+  if (/new_sensitive/i.test(apiMsg) || /output.*sensitive/i.test(apiMsg)) {
+    return new CLIError(
+      `Output withheld by content moderation (${apiMsg}).`,
+      ExitCode.CONTENT_FILTER,
+      'Refine your query and try again.',
+    );
+  }
+
   return new CLIError(
     `API error: ${apiMsg} (HTTP ${status})`,
     ExitCode.GENERAL,

--- a/src/errors/api.ts
+++ b/src/errors/api.ts
@@ -75,7 +75,7 @@ export function mapApiError(status: number, body: ApiErrorBody, url?: string): C
     (/sensitive content/i.test(apiMsg) || /(?:^|\D)1026(?:\D|$)/.test(apiMsg));
 
   // MiniMax content sensitivity filter
-  if (apiCode === 1002 || apiCode === 1039 || isV2ContentFilter) {
+  if (apiCode === 1002 || apiCode === 1039 || apiCode === 1026 || isV2ContentFilter) {
     const filterType =
       body.base_resp?.status_msg ||
       body.error?.message ||
@@ -107,7 +107,7 @@ export function mapApiError(status: number, body: ApiErrorBody, url?: string): C
   }
 
   // output sensitivity (status_code 1027, e.g. "output new_sensitive")
-  if (apiCode === 1027 || /new_sensitive/i.test(apiMsg) || /output.*sensitive/i.test(apiMsg)) {
+  if (apiCode === 1027 || /output.*sensitive/i.test(apiMsg)) {
     return new CLIError(
       `Output withheld by content moderation (${apiMsg}).`,
       ExitCode.CONTENT_FILTER,

--- a/test/errors/api.test.ts
+++ b/test/errors/api.test.ts
@@ -73,6 +73,16 @@ describe('mapApiError', () => {
     expect(err.exitCode).toBe(ExitCode.QUOTA);
   });
 
+  it('maps output sensitivity (HTTP 200) to CONTENT_FILTER', () => {
+    const err = mapApiError(200, {
+      base_resp: { status_code: 2001, status_msg: 'output new_sensitive' },
+    });
+    expect(err.exitCode).toBe(ExitCode.CONTENT_FILTER);
+    expect(err.message).toContain('content moderation');
+    expect(err.message).toContain('output new_sensitive');
+    expect(err.hint).toBeDefined();
+  });
+
   it('maps unknown errors to GENERAL', () => {
     const err = mapApiError(500, { base_resp: { status_code: 0, status_msg: 'internal error' } });
     expect(err.exitCode).toBe(ExitCode.GENERAL);

--- a/test/errors/api.test.ts
+++ b/test/errors/api.test.ts
@@ -90,6 +90,15 @@ describe('mapApiError', () => {
     expect(err.exitCode).toBe(ExitCode.CONTENT_FILTER);
   });
 
+  it('maps input sensitivity code 1026 to CONTENT_FILTER (not output)', () => {
+    const err = mapApiError(200, {
+      base_resp: { status_code: 1026, status_msg: 'input new_sensitive' },
+    });
+    expect(err.exitCode).toBe(ExitCode.CONTENT_FILTER);
+    expect(err.message).toContain('Input');
+    expect(err.message).not.toContain('Output withheld');
+  });
+
   it('maps unknown errors to GENERAL', () => {
     const err = mapApiError(500, { base_resp: { status_code: 0, status_msg: 'internal error' } });
     expect(err.exitCode).toBe(ExitCode.GENERAL);

--- a/test/errors/api.test.ts
+++ b/test/errors/api.test.ts
@@ -83,6 +83,13 @@ describe('mapApiError', () => {
     expect(err.hint).toBeDefined();
   });
 
+  it('maps output sensitivity code 1027 to CONTENT_FILTER', () => {
+    const err = mapApiError(200, {
+      base_resp: { status_code: 1027, status_msg: '输出内容涉敏' },
+    });
+    expect(err.exitCode).toBe(ExitCode.CONTENT_FILTER);
+  });
+
   it('maps unknown errors to GENERAL', () => {
     const err = mapApiError(500, { base_resp: { status_code: 0, status_msg: 'internal error' } });
     expect(err.exitCode).toBe(ExitCode.GENERAL);


### PR DESCRIPTION
Search requests that return HTTP 200 with `status_msg: "output new_sensitive"`
were falling through to the generic "API error" path (exit code 1), so a
moderation block looked like an API/CLI failure.

`mapApiError` now detects output-side sensitivity and maps it to
`ExitCode.CONTENT_FILTER` (10) with a clear message.

Added a test case in `test/errors/api.test.ts`.

Fixes #234

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/cli/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791225368&installation_model_id=427615&pr_number=256&repository=MiniMax-AI%2Fcli&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2Fcli%2Fpull%2F256&signature=3c9cb49a990457960fd532cf3d7e92f58df1e9dfadb4906f4090e88898bf4e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->